### PR TITLE
feat: archive of polling data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,10 @@ GITHUB_REPO=zweitstimme/data
 # Scraper settings
 SCRAPER_DELAY=1.0
 SCRAPER_TIMEOUT=30
+
+# S3 Archive (Hetzner S3-compatible)
+AWS_ACCESS_KEY_ID=your-access-key
+AWS_SECRET_ACCESS_KEY=your-secret-key
+AWS_S3_BUCKET_NAME=pollingapi-archive
+AWS_S3_REGION=eu-central-1
+AWS_S3_ENDPOINT_URL=https://s3.eu-central-1.hetzner.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
     "pydantic-settings>=2.6.0",
     # HTTP Client
     "httpx>=0.28.0",
+    # S3 Storage
+    "boto3>=1.35.0",
     # Utilities
     "toml>=0.10.2",
     "pyarrow>=23.0.0",

--- a/src/pollingapi/api/data.py
+++ b/src/pollingapi/api/data.py
@@ -1,0 +1,209 @@
+"""Archive API router for data downloads."""
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+
+from pollingapi.services.s3 import ArchiveMetadata, S3Service
+
+router = APIRouter(prefix="/archive", tags=["archive"])
+
+s3_service = S3Service()
+
+
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Data Archive - Zweitstimme Polling API</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 40px 20px;
+            background: #f5f5f5;
+        }
+        h1 { color: #333; margin-bottom: 10px; }
+        .subtitle { color: #666; margin-bottom: 30px; }
+        .archive-list { background: white; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.1); }
+        .archive-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 20px;
+            border-bottom: 1px solid #eee;
+        }
+        .archive-item:last-child { border-bottom: none; }
+        .archive-info { flex: 1; }
+        .archive-name { font-weight: 600; font-size: 16px; color: #333; }
+        .archive-meta { font-size: 13px; color: #888; margin-top: 4px; }
+        .download-btn {
+            background: #007bff;
+            color: white;
+            padding: 10px 20px;
+            border-radius: 6px;
+            text-decoration: none;
+            font-size: 14px;
+            font-weight: 500;
+            transition: background 0.2s;
+        }
+        .download-btn:hover { background: #0056b3; }
+        .empty { text-align: center; padding: 60px 20px; color: #888; }
+        .footer { margin-top: 30px; text-align: center; font-size: 13px; color: #888; }
+        .footer a { color: #007bff; text-decoration: none; }
+        .footer a:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <h1>Data Archive</h1>
+    <p class="subtitle">Download complete snapshots of the Zweitstimme polling database</p>
+
+    ARCHIVE_LIST
+
+    <div class="footer">
+        <p>Powered by <a href="https://github.com/zweitstimme-org/pollingAPI">Zweitstimme.org polling-api</a></p>
+    </div>
+</body>
+</html>"""
+
+ARCHIVE_ITEM_TEMPLATE = """        <div class="archive-item">
+            <div class="archive-info">
+                <div class="archive-name">ARCHIVE_NAME</div>
+                <div class="archive-meta">ARCHIVE_META</div>
+            </div>
+            <a href="ARCHIVE_URL" class="download-btn">Download</a>
+        </div>"""
+
+EMPTY_STATE = """    <div class="archive-list">
+        <div class="empty">
+            <p>No archives available yet.</p>
+            <p>Archives are created periodically. Check back later.</p>
+        </div>
+    </div>"""
+
+
+def format_size(size_bytes: int | float) -> str:
+    """Format file size in human-readable format."""
+    size = float(size_bytes)
+    for unit in ["B", "KB", "MB", "GB"]:
+        if size < 1024:
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} TB"
+
+
+def render_html_archive_list(archives: list[ArchiveMetadata]) -> str:
+    """Render HTML archive list."""
+    if not archives:
+        return HTML_TEMPLATE.replace("ARCHIVE_LIST", EMPTY_STATE)
+
+    items = []
+    for archive in archives:
+        size_str = format_size(archive.size)
+        date_str = archive.created_at.strftime("%B %d, %Y at %H:%M")
+        meta = f"{size_str} • {date_str}"
+
+        items.append(
+            ARCHIVE_ITEM_TEMPLATE.replace("ARCHIVE_NAME", archive.filename)
+            .replace("ARCHIVE_META", meta)
+            .replace("ARCHIVE_URL", archive.public_url)
+        )
+
+    list_html = """    <div class="archive-list">\n""" + "\n".join(items) + """\n    </div>"""
+    return HTML_TEMPLATE.replace("ARCHIVE_LIST", list_html)
+
+
+@router.get("", response_class=HTMLResponse)
+def list_archives_html():
+    """List all available data archives as HTML."""
+    archives = s3_service.list_archives()
+    return render_html_archive_list(archives)
+
+
+@router.get(".json")
+def list_archives_json():
+    """List all available data archives as JSON."""
+    archives = s3_service.list_archives()
+
+    if not s3_service.is_configured():
+        return JSONResponse(
+            {"error": "Archive service not configured", "archives": []},
+            status_code=503,
+        )
+
+    return {
+        "archives": [
+            {
+                "filename": a.filename,
+                "size": a.size,
+                "size_formatted": format_size(a.size),
+                "created_at": a.created_at.isoformat(),
+                "download_url": a.public_url,
+            }
+            for a in archives
+        ],
+        "count": len(archives),
+    }
+
+
+@router.get("latest")
+def get_latest_archive():
+    """Get the latest archive."""
+    archives = s3_service.list_archives()
+
+    if not s3_service.is_configured():
+        return JSONResponse(
+            {"error": "Archive service not configured"},
+            status_code=503,
+        )
+
+    if not archives:
+        raise HTTPException(status_code=404, detail="No archives available")
+
+    latest = archives[0]
+    return {
+        "filename": latest.filename,
+        "size": latest.size,
+        "size_formatted": format_size(latest.size),
+        "created_at": latest.created_at.isoformat(),
+        "download_url": latest.public_url,
+    }
+
+
+@router.get("{filename}")
+def get_archive(filename: str):
+    """Get metadata for a specific archive."""
+    archive = s3_service.get_archive(filename)
+
+    if not s3_service.is_configured():
+        return JSONResponse(
+            {"error": "Archive service not configured"},
+            status_code=503,
+        )
+
+    if not archive:
+        raise HTTPException(status_code=404, detail="Archive not found")
+
+    return {
+        "filename": archive.filename,
+        "size": archive.size,
+        "size_formatted": format_size(archive.size),
+        "created_at": archive.created_at.isoformat(),
+        "download_url": archive.public_url,
+    }
+
+
+@router.get("{filename}/download")
+def download_archive(filename: str):
+    """Redirect to download URL for a specific archive."""
+    archive = s3_service.get_archive(filename)
+
+    if not s3_service.is_configured():
+        raise HTTPException(status_code=503, detail="Archive service not configured")
+
+    if not archive:
+        raise HTTPException(status_code=404, detail="Archive not found")
+
+    return RedirectResponse(url=archive.public_url)

--- a/src/pollingapi/cli.py
+++ b/src/pollingapi/cli.py
@@ -7,11 +7,12 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from pollingapi.cleaner import run_cleaning_pipeline
-from pollingapi.core import settings
+from pollingapi.core import PROJECT_ROOT, settings
 from pollingapi.database import SessionLocal, init_db, seed_all_from_json
 from pollingapi.logging_config import get_logger, setup_logging
 from pollingapi.scraper.context import RunContext
 from pollingapi.scraper.runner import ScraperRunner
+from pollingapi.services.s3 import S3Service
 
 # Initialize logging with default settings
 setup_logging()
@@ -108,9 +109,11 @@ def db_tables():
         typer.echo(f"  {name}: {count}")
 
 
-@app.command(name="export:all")
-def db_export():
-    """Export data to JSON, CSV, and Parquet files."""
+def _run_export() -> dict:
+    """Run data export to JSON, CSV, and Parquet files.
+
+    Returns a dict with export statistics.
+    """
     import json
 
     import pandas as pd
@@ -119,7 +122,6 @@ def db_export():
 
     db = get_db()
 
-    # Export polls
     polls = db.query(Poll).all()
     polls_data = []
     for poll in polls:
@@ -144,7 +146,6 @@ def db_export():
     with open(settings.export_dir / "polls.json", "w", encoding="utf-8") as f:
         json.dump(polls_data, f, indent=2, ensure_ascii=False)
 
-    # Export flattened poll results
     poll_results_data = []
     for poll in polls_data:
         for result in poll.get("results", []):
@@ -162,19 +163,16 @@ def db_export():
     with open(settings.export_dir / "poll_results.json", "w", encoding="utf-8") as f:
         json.dump(poll_results_data, f, indent=2, ensure_ascii=False)
 
-    # Export CSV (without nested results)
     polls_df = pd.DataFrame(polls_data)
     if "results" in polls_df.columns:
         polls_df = polls_df.drop(columns=["results"])
     polls_df.to_csv(settings.export_dir / "polls.csv", index=False)
 
-    # Export Parquet if available
     try:
         polls_df.to_parquet(settings.export_dir / "polls.parquet", index=False)
     except Exception as exc:
         logger.warning(f"Could not export Parquet: {exc}")
 
-    # Export raw polls
     raw_polls = db.query(RawPoll).all()
     raw_data = []
     for raw in raw_polls:
@@ -200,9 +198,20 @@ def db_export():
     with open(settings.export_dir / "polls_raw.json", "w", encoding="utf-8") as f:
         json.dump(raw_data, f, indent=2, ensure_ascii=False, default=str)
 
+    return {
+        "polls": len(polls_data),
+        "poll_results": len(poll_results_data),
+        "raw_polls": len(raw_data),
+    }
+
+
+@app.command(name="export:all")
+def db_export():
+    """Export data to JSON, CSV, and Parquet files."""
+    stats = _run_export()
     typer.echo(
-        f"✓ Exported {len(polls_data)} polls, {len(poll_results_data)} poll results, "
-        f"and {len(raw_data)} raw polls to {settings.export_dir}"
+        f"✓ Exported {stats['polls']} polls, {stats['poll_results']} poll results, "
+        f"and {stats['raw_polls']} raw polls to {settings.export_dir}"
     )
 
 
@@ -294,8 +303,6 @@ def scraper_list():
 @app.command(name="scraper:status")
 def scraper_status():
     """Show scraper run status and data freshness."""
-
-    from pollingapi.core import settings
 
     typer.echo("Scraper status:")
     typer.echo("-" * 50)
@@ -632,6 +639,131 @@ def logs_list():
             typer.echo(f"  ✓ {log_file}: {size_str}")
         else:
             typer.echo(f"  ○ {log_file}: not created yet")
+
+
+# ============================================================================
+# Data Archive Commands (data:*)
+# ============================================================================
+
+
+@app.command(name="data:archive")
+def data_archive(
+    keep: bool = typer.Option(False, "--keep", help="Keep local archive after upload"),
+):
+    """Create and upload data archive to S3."""
+    import shutil
+    from datetime import date
+
+    s3_service = S3Service()
+
+    if not s3_service.is_configured():
+        typer.echo("✗ S3 not configured. Check AWS environment variables.", err=True)
+        typer.echo("\nRequired environment variables:")
+        typer.echo("  AWS_ACCESS_KEY_ID")
+        typer.echo("  AWS_SECRET_ACCESS_KEY")
+        typer.echo("  AWS_S3_BUCKET_NAME")
+        typer.echo("  AWS_S3_REGION")
+        typer.echo("  AWS_S3_ENDPOINT_URL (for S3-compatible services)")
+        raise typer.Exit(1)
+
+    typer.echo("Running data export...")
+
+    export_stats = _run_export()
+    typer.echo(
+        f"✓ Exported {export_stats['polls']} polls, {export_stats['poll_results']} poll results, "
+        f"and {export_stats['raw_polls']} raw polls"
+    )
+
+    typer.echo("\nCreating data archive...")
+
+    data_dir = settings.data_dir
+    json_dir = PROJECT_ROOT / "json"
+
+    if not data_dir.exists():
+        typer.echo(f"✗ Data directory not found: {data_dir}", err=True)
+        raise typer.Exit(1)
+
+    if not json_dir.exists():
+        typer.echo(f"✗ JSON directory not found: {json_dir}", err=True)
+        raise typer.Exit(1)
+
+    archive_name = f"pollingapi-archive-{date.today().isoformat()}.zip"
+    archive_path = settings.data_dir.parent / archive_name
+
+    try:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+
+            import shutil as sh
+
+            sh.copytree(data_dir, tmp_path / "data")
+            sh.copytree(json_dir, tmp_path / "json")
+
+            shutil.make_archive(
+                base_name=str(archive_path.with_suffix("")),
+                format="zip",
+                root_dir=str(tmp_path),
+            )
+
+        archive_size = archive_path.stat().st_size
+        typer.echo(f"✓ Created archive: {archive_name} ({archive_size / 1024 / 1024:.1f} MB)")
+
+        typer.echo(f"Uploading to S3 bucket: {s3_service.bucket_name}...")
+
+        key = f"archives/{archive_name}"
+        if s3_service.upload_archive(archive_path, key):
+            typer.echo(f"✓ Uploaded to s3://{s3_service.bucket_name}/{key}")
+
+            archives = s3_service.list_archives()
+            s3_service.upload_index(archives)
+            typer.echo("✓ Updated archive index")
+
+            if not keep:
+                archive_path.unlink()
+                typer.echo(f"✓ Removed local archive: {archive_name}")
+            else:
+                typer.echo(f"✓ Kept local archive: {archive_path}")
+
+            typer.echo("\nArchive available at:")
+            typer.echo("  /v1/archive")
+            typer.echo("  /v1/archive.json")
+        else:
+            typer.echo("✗ Failed to upload to S3", err=True)
+            raise typer.Exit(1)
+
+    except Exception as e:
+        logger.error(f"Failed to create archive: {e}")
+        typer.echo(f"✗ Error: {e}", err=True)
+        if archive_path.exists():
+            archive_path.unlink()
+        raise typer.Exit(1)
+
+
+@app.command(name="data:list")
+def data_list():
+    """List available data archives in S3."""
+    s3_service = S3Service()
+
+    if not s3_service.is_configured():
+        typer.echo("✗ S3 not configured.", err=True)
+        raise typer.Exit(1)
+
+    archives = s3_service.list_archives()
+
+    if not archives:
+        typer.echo("No archives found in S3 bucket.")
+        return
+
+    typer.echo(f"Available archives in {s3_service.bucket_name}:")
+    typer.echo("-" * 60)
+    for archive in archives:
+        size_mb = archive.size / 1024 / 1024
+        date_str = archive.created_at.strftime("%Y-%m-%d %H:%M")
+        typer.echo(f"  {archive.filename}")
+        typer.echo(f"    Size: {size_mb:.1f} MB | Date: {date_str}")
+        typer.echo(f"    URL: {archive.public_url}")
 
 
 # ============================================================================

--- a/src/pollingapi/core/__init__.py
+++ b/src/pollingapi/core/__init__.py
@@ -1,7 +1,6 @@
 """Core configuration module."""
 
 from pathlib import Path
-from typing import Optional
 
 from pydantic_settings import BaseSettings
 
@@ -36,6 +35,13 @@ class Settings(BaseSettings):
     # Scraping Configuration
     scraper_delay: float = 1.0  # Seconds between requests
     scraper_timeout: int = 30  # Request timeout
+
+    # S3 Archive Configuration
+    aws_access_key_id: str | None = None
+    aws_secret_access_key: str | None = None
+    aws_s3_bucket_name: str | None = None
+    aws_s3_region: str = "eu-central-1"
+    aws_s3_endpoint_url: str | None = None  # For S3-compatible services (Hetzner, MinIO, etc.)
 
     # Data Paths
     data_dir: Path = DATA_DIR

--- a/src/pollingapi/main.py
+++ b/src/pollingapi/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from pollingapi.api import (
+    data,
     dictionaries,
     download,
     elections,
@@ -37,6 +38,7 @@ app = FastAPI(
         {"name": "reference", "description": "Reference/dictionary tables"},
         {"name": "elections", "description": "Election summaries and metadata"},
         {"name": "downloads", "description": "File exports (JSON/CSV/SQLite)"},
+        {"name": "archive", "description": "Data archive downloads (S3)"},
     ],
 )
 
@@ -56,6 +58,7 @@ app.include_router(polls.results_router, prefix="/v1")
 app.include_router(download.router, prefix="/v1", tags=["downloads"])
 app.include_router(elections.router, prefix="/v1")
 app.include_router(dictionaries.router, prefix="/v1")
+app.include_router(data.router, prefix="/v1")
 
 
 @app.get("/")

--- a/src/pollingapi/services/__init__.py
+++ b/src/pollingapi/services/__init__.py
@@ -1,0 +1,5 @@
+"""Services package for pollingAPI."""
+
+from pollingapi.services.s3 import S3Service
+
+__all__ = ["S3Service"]

--- a/src/pollingapi/services/s3.py
+++ b/src/pollingapi/services/s3.py
@@ -1,0 +1,167 @@
+"""S3 service for archive management."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+from pollingapi.core import settings
+from pollingapi.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class ArchiveMetadata:
+    """Metadata for an archive file."""
+
+    filename: str
+    key: str
+    size: int
+    created_at: datetime
+    public_url: str
+
+
+class S3Service:
+    """Service for managing data archives in S3."""
+
+    def __init__(self) -> None:
+        """Initialize S3 service with configuration."""
+        self.bucket_name = settings.aws_s3_bucket_name
+        self.region = settings.aws_s3_region
+        self.endpoint_url = settings.aws_s3_endpoint_url
+        self._client = None
+
+    @property
+    def client(self):
+        """Get or create S3 client."""
+        if self._client is None:
+            config = Config(signature_version="s3v4")
+            self._client = boto3.client(
+                "s3",
+                aws_access_key_id=settings.aws_access_key_id,
+                aws_secret_access_key=settings.aws_secret_access_key,
+                endpoint_url=self.endpoint_url,
+                region_name=self.region,
+                config=config,
+            )
+        return self._client
+
+    def is_configured(self) -> bool:
+        """Check if S3 is properly configured."""
+        return (
+            settings.aws_access_key_id is not None
+            and settings.aws_secret_access_key is not None
+            and settings.aws_s3_bucket_name is not None
+        )
+
+    def _get_public_url(self, key: str) -> str:
+        """Generate public URL for an object."""
+        if self.endpoint_url:
+            base_url = self.endpoint_url.rstrip("/")
+            return f"{base_url}/{self.bucket_name}/{key}"
+        return f"https://{self.bucket_name}.s3.{self.region}.amazonaws.com/{key}"
+
+    def list_archives(self, prefix: str = "archives/") -> list[ArchiveMetadata]:
+        """List all archive files in the bucket."""
+        if not self.is_configured():
+            logger.warning("S3 not configured, returning empty archive list")
+            return []
+
+        try:
+            response = self.client.list_objects_v2(
+                Bucket=self.bucket_name,
+                Prefix=prefix,
+            )
+
+            archives = []
+            for obj in response.get("Contents", []):
+                key = obj["Key"]
+                if key.endswith(".zip"):
+                    archives.append(
+                        ArchiveMetadata(
+                            filename=key.split("/")[-1],
+                            key=key,
+                            size=obj["Size"],
+                            created_at=obj["LastModified"],
+                            public_url=self._get_public_url(key),
+                        )
+                    )
+
+            archives.sort(key=lambda x: x.created_at, reverse=True)
+            return archives
+        except ClientError as e:
+            logger.error(f"Failed to list archives: {e}")
+            return []
+
+    def upload_archive(
+        self,
+        file_path: Path,
+        key: str | None = None,
+    ) -> bool:
+        """Upload an archive file to S3."""
+        if not self.is_configured():
+            logger.error("S3 not configured")
+            return False
+
+        if key is None:
+            key = f"archives/{file_path.name}"
+
+        try:
+            self.client.upload_file(
+                str(file_path),
+                self.bucket_name,
+                key,
+                ExtraArgs={"ACL": "public-read"},
+            )
+            logger.info(f"Uploaded {file_path.name} to s3://{self.bucket_name}/{key}")
+            return True
+        except ClientError as e:
+            logger.error(f"Failed to upload archive: {e}")
+            return False
+
+    def upload_index(self, archives: list[ArchiveMetadata]) -> bool:
+        """Upload archive index JSON to bucket."""
+        import json
+
+        if not self.is_configured():
+            logger.error("S3 not configured")
+            return False
+
+        index_data = {
+            "archives": [
+                {
+                    "filename": a.filename,
+                    "size": a.size,
+                    "created_at": a.created_at.isoformat(),
+                    "download_url": a.public_url,
+                }
+                for a in archives
+            ],
+            "updated_at": datetime.utcnow().isoformat(),
+        }
+
+        try:
+            self.client.put_object(
+                Bucket=self.bucket_name,
+                Key="archive-index.json",
+                Body=json.dumps(index_data, indent=2),
+                ContentType="application/json",
+                ACL="public-read",
+            )
+            logger.info("Uploaded archive index to s3")
+            return True
+        except ClientError as e:
+            logger.error(f"Failed to upload index: {e}")
+            return False
+
+    def get_archive(self, filename: str) -> ArchiveMetadata | None:
+        """Get a specific archive by filename."""
+        archives = self.list_archives()
+        for archive in archives:
+            if archive.filename == filename:
+                return archive
+        return None

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -84,6 +84,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.42.65"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1e/c9/8ff8a901cf62374f1289cf36391f855e1702c70f545c28d1b57608a84ff2/boto3-1.42.65.tar.gz", hash = "sha256:c740af6bdaebcc1a00f3827a5729050bf6fc820ee148bf7d06f28db11c80e2a1", size = 112805, upload-time = "2026-03-10T19:44:58.255Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/bb/ace5921655df51e3c9b787b3f0bd6aa25548e5cf1dabae02e53fa88f2d98/boto3-1.42.65-py3-none-any.whl", hash = "sha256:cc7f2e0aec6c68ee5b10232cf3e01326acf6100bc785a770385b61a0474b31f4", size = 140556, upload-time = "2026-03-10T19:44:55.433Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.65"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/81/2c832e2117d24da4fe800861e8ddd19bbaa308623b1198eb2c2cc6fcd3d4/botocore-1.42.65.tar.gz", hash = "sha256:7d52c148df07f70c375eeda58f99b439c7c7836c25df74cccfba3bb6e12444d2", size = 14970239, upload-time = "2026-03-10T19:44:43.686Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/9e/2ca03a55408c0820d7f0a04ae52bc6dfc7e4fff1f007a90135a68e056c93/botocore-1.42.65-py3-none-any.whl", hash = "sha256:0283c332ce00cbd1b894e86b7bed89dd624a5ca3a4ee62ec4db3898d16652e98", size = 14644794, upload-time = "2026-03-10T19:44:37.442Z" },
 ]
 
 [[package]]
@@ -594,6 +622,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -1127,6 +1164,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "beautifulsoup4" },
+    { name = "boto3" },
     { name = "dateparser" },
     { name = "fastapi", extra = ["standard"] },
     { name = "greenlet" },
@@ -1170,6 +1208,7 @@ dev = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
+    { name = "boto3", specifier = ">=1.35.0" },
     { name = "dateparser", specifier = ">=1.2.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
     { name = "greenlet", specifier = ">=3.1.0" },
@@ -1748,6 +1787,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/b0/69adf22f4e24f3677208adb715c578266842e6e6a3cc77483f48dd999ede/ruff-0.15.0-py3-none-win32.whl", hash = "sha256:238a717ef803e501b6d51e0bdd0d2c6e8513fe9eec14002445134d3907cd46c3", size = 10465945, upload-time = "2026-02-03T17:53:12.591Z" },
     { url = "https://files.pythonhosted.org/packages/51/ad/f813b6e2c97e9b4598be25e94a9147b9af7e60523b0cb5d94d307c15229d/ruff-0.15.0-py3-none-win_amd64.whl", hash = "sha256:dd5e4d3301dc01de614da3cdffc33d4b1b96fb89e45721f1598e5532ccf78b18", size = 11564657, upload-time = "2026-02-03T17:52:51.893Z" },
     { url = "https://files.pythonhosted.org/packages/f6/b0/2d823f6e77ebe560f4e397d078487e8d52c1516b331e3521bc75db4272ca/ruff-0.15.0-py3-none-win_arm64.whl", hash = "sha256:c480d632cc0ca3f0727acac8b7d053542d9e114a462a145d0b00e7cd658c515a", size = 10865753, upload-time = "2026-02-03T17:53:03.014Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR introduces S3-based data archiving with a public directory listing.

## New functionality:
- /v1/archive endpoint returns an HTML page listing all available archives with download links
- JSON endpoint at /v1/archive.json for programmatic access
- data:archive CLI command creates and uploads a complete data snapshot
- data:list CLI command shows archives in the S3 bucket

## Behavior:
- The archive command runs the export pipeline first, then packages data/ and json/ directories into a ZIP file
- Archives are uploaded to a configurable S3-compatible bucket 
- The archive index is automatically updated after each upload

## Configuration:
- New environment variables for S3 credentials and endpoint URL
- Requires boto3 dependency