### PR TITLE
Feat/importer

### DIFF
--- a/import_urls.txt
+++ b/import_urls.txt
@@ -1,0 +1,10 @@
+# Import downloads.
+#
+# Each non-comment line is either:
+#   local_filename.xlsx https://example.com/data.xlsx
+# or:
+#   https://example.com/data.xlsx
+#
+# Relative destinations are written below the top-level imports/ directory.
+
+KAYSER_REHMERT.xlsx https://media.githubusercontent.com/media/coalition-leverage/cip-webpage/main/data/polling_data.xlsx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.7.1",
     "mkdocs-minify-plugin>=0.8.0",
+    "openpyxl>=3.1.5",
 ]
 
 [project.optional-dependencies]

--- a/src/pollingapi/cli.py
+++ b/src/pollingapi/cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
+from httpx import HTTPError
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -11,7 +12,7 @@ from pollingapi.cleaner import run_cleaning_pipeline
 from pollingapi.core import PROJECT_ROOT, settings
 from pollingapi.data_validation import DataValidationService, ValidationReportService
 from pollingapi.database import SessionLocal, init_db, seed_all_from_json
-from pollingapi.importer import IMPORTS_DIR, ImportRunner
+from pollingapi.importer import DEFAULT_MANIFEST, IMPORTS_DIR, ImportRunner, download_from_manifest
 from pollingapi.logging_config import get_logger, setup_logging
 from pollingapi.notifications import PipelineRunResult, create_notification_manager
 from pollingapi.scraper.context import RunContext
@@ -35,6 +36,10 @@ ImportSourceOption = Annotated[str, typer.Option("--source", "-s", help="Import 
 ImportPreviewLimitOption = Annotated[
     int,
     typer.Option("--limit", "-l", help="Number of rows to preview"),
+]
+ImportManifestOption = Annotated[
+    Path,
+    typer.Option("--manifest", "-m", help="Download manifest path"),
 ]
 
 
@@ -362,6 +367,29 @@ def import_list():
         typer.echo(f"  • {name}")
     typer.echo("")
     typer.echo(f"Import directory: {IMPORTS_DIR}")
+
+
+@app.command(name="import:download")
+def import_download(
+    manifest: ImportManifestOption = DEFAULT_MANIFEST,
+    force: bool = typer.Option(False, "--force", "-f", help="Redownload existing files"),
+    timeout: float = typer.Option(60.0, "--timeout", help="HTTP timeout in seconds"),
+):
+    """Download import files declared in the project root manifest."""
+    try:
+        results = download_from_manifest(manifest_path=manifest, force=force, timeout=timeout)
+    except (FileNotFoundError, HTTPError, ValueError) as exc:
+        typer.echo(f"✗ {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+    typer.echo(f"Import downloads from {manifest}:")
+    if not results:
+        typer.echo("  No URLs configured")
+        return
+
+    for result in results:
+        status = "downloaded" if result.downloaded else "skipped"
+        typer.echo(f"  {status}: {result.destination} ({result.bytes_written} bytes)")
 
 
 @app.command(name="import:preview")

--- a/src/pollingapi/cli.py
+++ b/src/pollingapi/cli.py
@@ -1,6 +1,7 @@
 """CLI entry points for zweitstimme."""
 
 from pathlib import Path
+from typing import Annotated
 
 import typer
 from sqlalchemy import text
@@ -10,6 +11,7 @@ from pollingapi.cleaner import run_cleaning_pipeline
 from pollingapi.core import PROJECT_ROOT, settings
 from pollingapi.data_validation import DataValidationService, ValidationReportService
 from pollingapi.database import SessionLocal, init_db, seed_all_from_json
+from pollingapi.importer import IMPORTS_DIR, ImportRunner
 from pollingapi.logging_config import get_logger, setup_logging
 from pollingapi.notifications import PipelineRunResult, create_notification_manager
 from pollingapi.scraper.context import RunContext
@@ -24,6 +26,16 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 logger = get_logger(__name__)
+
+ImportFileArg = Annotated[
+    Path,
+    typer.Argument(help="Import file path, relative to ./imports if not absolute"),
+]
+ImportSourceOption = Annotated[str, typer.Option("--source", "-s", help="Import source name")]
+ImportPreviewLimitOption = Annotated[
+    int,
+    typer.Option("--limit", "-l", help="Number of rows to preview"),
+]
 
 
 def get_db() -> Session:
@@ -336,6 +348,83 @@ def scraper_status():
             typer.echo(f"  ✓ {worker}: Historic data processed")
         else:
             typer.echo(f"  ○ {worker}: Awaiting initial run")
+
+
+@app.command(name="import:list")
+def import_list():
+    """List available data import sources."""
+    db = get_db()
+    runner = ImportRunner(db)
+
+    typer.echo("Available import sources:")
+    typer.echo("-" * 50)
+    for name in runner.list_sources():
+        typer.echo(f"  • {name}")
+    typer.echo("")
+    typer.echo(f"Import directory: {IMPORTS_DIR}")
+
+
+@app.command(name="import:preview")
+def import_preview(
+    file: ImportFileArg,
+    source: ImportSourceOption = "csv",
+    limit: ImportPreviewLimitOption = 10,
+):
+    """Preview parsed import rows without writing to the database."""
+    db = get_db()
+    runner = ImportRunner(db)
+
+    try:
+        rows = runner.preview(source, file, limit=limit)
+    except (FileNotFoundError, ValueError) as exc:
+        typer.echo(f"✗ {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+    typer.echo(f"Previewing {len(rows)} row(s):")
+    for index, row in enumerate(rows, start=1):
+        data = row.to_raw_dict()
+        typer.echo(f"  {index}. {data['publish_date']} | {data['institute_id']} | {data['scope']}")
+        typer.echo(f"     parties: {data['parties']}")
+
+
+@app.command(name="import:run")
+def import_run(
+    file: ImportFileArg,
+    source: ImportSourceOption = "csv",
+    clean: bool = typer.Option(False, "--clean", help="Run cleaner after importing"),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", "-n", help="Parse and dedupe without committing"
+    ),
+):
+    """Import file data into polls_raw."""
+    db = get_db()
+    runner = ImportRunner(db)
+
+    try:
+        result = runner.run(source, file, clean=clean, dry_run=dry_run)
+    except (FileNotFoundError, ValueError) as exc:
+        typer.echo(f"✗ {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+    if result.stats.errors:
+        typer.echo("✗ Import failed:", err=True)
+        for message in result.stats.error_messages:
+            typer.echo(f"  {message}", err=True)
+        raise typer.Exit(1)
+
+    action = "Would import" if dry_run else "Imported"
+    typer.echo(f"✓ {action} data from {result.path}:")
+    typer.echo(f"  Parsed: {result.stats.parsed}")
+    typer.echo(f"  Inserted: {result.stats.inserted}")
+    typer.echo(f"  Skipped: {result.stats.skipped}")
+
+    if result.cleaning_stats:
+        typer.echo("  Cleaner:")
+        typer.echo(f"    Processed: {result.cleaning_stats['processed']}")
+        typer.echo(f"    Created: {result.cleaning_stats['created']}")
+        typer.echo(f"    Updated: {result.cleaning_stats['updated']}")
+        typer.echo(f"    Skipped: {result.cleaning_stats['skipped']}")
+        typer.echo(f"    Errors: {result.cleaning_stats['errors']}")
 
 
 @app.command(name="pipeline:clean")

--- a/src/pollingapi/importer/README.md
+++ b/src/pollingapi/importer/README.md
@@ -19,6 +19,7 @@ Importer code lives in `src/pollingapi/importer`.
 src/pollingapi/importer/
 ├── formats/          # Low-level file readers
 ├── sources/          # Source-specific adapters
+├── download.py        # Downloads files declared in import_urls.txt
 ├── insertion.py      # RawPoll insert and dedupe logic
 ├── runner.py         # Top-level import orchestration
 └── schemas.py        # Import models and result types
@@ -33,6 +34,57 @@ imports/
 
 When a CLI command receives a relative file path, it resolves that path relative
 to `imports/`. Absolute file paths are also supported.
+
+## Downloading Source Files
+
+Importer downloads are configured in the project root file `import_urls.txt`.
+This file is intentionally simple. Blank lines and comments are ignored.
+
+Use an explicit destination filename:
+
+```text
+source_name/raw.xlsx https://example.com/data.xlsx
+```
+
+Or provide only a URL and let the importer infer the filename:
+
+```text
+https://example.com/data.xlsx
+```
+
+All relative destinations are written below the top-level `imports/` directory.
+For example, this manifest line:
+
+```text
+polls/raw.xlsx https://example.com/data.xlsx
+```
+
+writes the downloaded file to:
+
+```text
+imports/polls/raw.xlsx
+```
+
+Download configured files with:
+
+```bash
+uv run pollingapi import:download
+```
+
+By default, existing files are skipped. Use `--force` to redownload:
+
+```bash
+uv run pollingapi import:download --force
+```
+
+Use a different manifest file if needed:
+
+```bash
+uv run pollingapi import:download --manifest path/to/import_urls.txt
+```
+
+The download step only places files in `imports/`. Parsing and database insertion
+are still handled by `import:preview` and `import:run`.
 
 ## Import Sources
 

--- a/src/pollingapi/importer/README.md
+++ b/src/pollingapi/importer/README.md
@@ -89,7 +89,8 @@ are still handled by `import:preview` and `import:run`.
 ## Import Sources
 
 An import source converts one input file into rows that match the `polls_raw`
-schema. The built-in source is `csv`, also available as `manual_csv`.
+schema. The built-in generic source is `csv`, also available as `manual_csv`.
+Source-specific importers can be registered for files that need custom parsing.
 
 List available sources with:
 
@@ -174,6 +175,74 @@ Use a dry run to parse and dedupe without committing:
 ```bash
 uv run pollingapi import:run forsa_manual.csv --dry-run
 ```
+
+## Kayser/Rehmert XLSX Workflow
+
+The Kayser/Rehmert data source is an XLSX file in long format. Each row contains
+one party result, not one complete poll. The importer source
+`kayser_rehmert` groups those rows into raw poll records.
+
+The expected file location is:
+
+```text
+imports/KAYSER_REHMERT.xlsx
+```
+
+Preview the parsed rows:
+
+```bash
+uv run pollingapi import:preview KAYSER_REHMERT.xlsx --source kayser_rehmert --limit 5
+```
+
+Run a dry import without committing:
+
+```bash
+uv run pollingapi import:run KAYSER_REHMERT.xlsx --source kayser_rehmert --dry-run
+```
+
+Import into `polls_raw` and immediately run the cleaner:
+
+```bash
+uv run pollingapi import:run KAYSER_REHMERT.xlsx --source kayser_rehmert --clean
+```
+
+The Kayser/Rehmert importer applies these source-specific rules:
+
+```text
+country_iso3c = DEU                 keep only Germany
+original_date = 1                   keep only original poll observations
+survey_date + institute             group long rows into one poll
+survey_date                         mapped to publish_date
+scope                               Bund
+election_id                         Bundestagswahl
+provider                            Kayser/Rehmert
+source                              xlsx_import:kayser_rehmert
+worker                              import:kayser_rehmert
+method_id                           99
+```
+
+The workbook does not provide a separate publication date, survey start/end,
+respondent count, commissioner, or survey method. Those fields are therefore
+left empty or unknown and handled by the normal cleaner defaults.
+
+Party labels are mapped to names the cleaner already understands:
+
+```text
+CDU/CSU     -> CDU/CSU
+SPD         -> SPD
+FDP         -> FDP
+Greens      -> Grüne
+PDS/Linke   -> Linke
+AfD         -> AfD
+BSW         -> BSW
+FW          -> FW
+Other       -> Sonstige
+```
+
+Some source rows have multiple values for the same party on the same
+`survey_date + institute` group. Those groups are ambiguous because the workbook
+does not provide a poll-level identifier to split them safely. The importer
+skips those conflicting groups instead of guessing.
 
 ## What Gets Written
 

--- a/src/pollingapi/importer/README.md
+++ b/src/pollingapi/importer/README.md
@@ -1,0 +1,238 @@
+# Data Importer
+
+The importer loads external data files into `polls_raw`. It does not write
+directly to the cleaned `polls` or `poll_results` tables. After raw rows are
+inserted, the existing cleaner can process them through the same normalization
+path used for scraper data.
+
+This keeps one rule for all data sources:
+
+```text
+file import -> polls_raw -> cleaner -> polls + poll_results
+```
+
+## Directory Layout
+
+Importer code lives in `src/pollingapi/importer`.
+
+```text
+src/pollingapi/importer/
+├── formats/          # Low-level file readers
+├── sources/          # Source-specific adapters
+├── insertion.py      # RawPoll insert and dedupe logic
+├── runner.py         # Top-level import orchestration
+└── schemas.py        # Import models and result types
+```
+
+Data files should live in the top-level `imports/` directory:
+
+```text
+imports/
+└── polling_data.csv
+```
+
+When a CLI command receives a relative file path, it resolves that path relative
+to `imports/`. Absolute file paths are also supported.
+
+## Import Sources
+
+An import source converts one input file into rows that match the `polls_raw`
+schema. The built-in source is `csv`, also available as `manual_csv`.
+
+List available sources with:
+
+```bash
+uv run pollingapi import:list
+```
+
+The generic CSV source supports two styles for party results:
+
+1. Party results as separate columns.
+2. Party results as a JSON object in a `parties` or `results` column.
+
+## CSV Format
+
+A typical CSV can look like this:
+
+```csv
+publish_date,institut,scope,election_id,respondents,CDU/CSU,SPD,GRÜNE,FDP,AfD,Linke
+2024-06-01,Forsa,Bund,Bundestagswahl,1000,30,16,13,5,18,3
+```
+
+The importer recognizes common aliases for the raw metadata fields. For example:
+
+```text
+publish_date: publish_date, datum, date, published_at
+institute_id: institute_id, institut, institute
+respondents: respondents, befragte, sample_size
+scope: scope, state, land
+election_id: election_id, election, election_type
+method_id: method_id, method, survey_method
+tasker: tasker, auftraggeber, commissioner
+```
+
+Columns that are not recognized as metadata are treated as party result columns.
+Their names are preserved because the cleaner uses those names for party
+normalization.
+
+Alternatively, results can be provided as JSON:
+
+```csv
+publish_date,institut,scope,election_id,respondents,parties
+2024-06-01,Forsa,Bund,Bundestagswahl,1000,"{""CDU/CSU"": ""30"", ""SPD"": ""16""}"
+```
+
+## Workflow
+
+Put the file into `imports/`:
+
+```text
+imports/forsa_manual.csv
+```
+
+Preview how the importer parses it:
+
+```bash
+uv run pollingapi import:preview forsa_manual.csv
+```
+
+The preview command does not write to the database. It parses the file and shows
+the raw rows that would be inserted.
+
+Import the file into `polls_raw`:
+
+```bash
+uv run pollingapi import:run forsa_manual.csv
+```
+
+Import and immediately run the cleaner:
+
+```bash
+uv run pollingapi import:run forsa_manual.csv --clean
+```
+
+Use a specific source if needed:
+
+```bash
+uv run pollingapi import:run forsa_manual.csv --source csv --clean
+```
+
+Use a dry run to parse and dedupe without committing:
+
+```bash
+uv run pollingapi import:run forsa_manual.csv --dry-run
+```
+
+## What Gets Written
+
+The importer writes `RawPoll` rows with fields such as:
+
+```text
+publish_date
+survey_date_start
+survey_date_end
+respondents
+zeitraum
+parties
+institute_id
+provider
+tasker
+source
+scope
+election_id
+method_id
+worker
+survey_type
+date_downloaded
+pipeline_run_id
+```
+
+For CSV imports, the default values are:
+
+```text
+source = csv_import
+method_id = 99
+worker = import:csv
+date_downloaded = current timestamp, if not supplied
+```
+
+The `parties` field is stored as JSON text, matching the existing raw scraper
+format.
+
+## Deduplication
+
+Before inserting a row, the importer checks whether an equivalent row already
+exists in `polls_raw`. It also deduplicates repeated rows inside the same import
+file.
+
+The dedupe key includes the raw poll metadata and party payload:
+
+```text
+publish_date
+survey_date_start
+survey_date_end
+respondents
+zeitraum
+parties
+institute_id
+provider
+tasker
+source
+scope
+election_id
+method_id
+worker
+survey_type
+```
+
+If a row matches this key, it is skipped instead of inserted again.
+
+## Cleaning Imported Data
+
+Imported rows are cleaned by the existing ETL pipeline. The cleaner reads from
+`polls_raw`, normalizes dates, respondents, institutes, methods, election scope,
+and party names, and then writes to `polls` and `poll_results`.
+
+You can run the cleaner as part of import:
+
+```bash
+uv run pollingapi import:run forsa_manual.csv --clean
+```
+
+Or run it separately:
+
+```bash
+uv run pollingapi pipeline:clean
+```
+
+Imported rows therefore follow the same rules as scraper rows. Unknown parties,
+invalid dates, duplicate cleaned fingerprints, and other data quality concerns
+are handled by the existing cleaner and validation logic.
+
+## Adding a Source-Specific Importer
+
+Use a source-specific importer when a file format needs custom parsing that the
+generic CSV source should not own.
+
+Add a new module in `src/pollingapi/importer/sources/` and implement
+`ImportSource`:
+
+```python
+from pathlib import Path
+
+from pollingapi.importer.schemas import RawPollImport
+from pollingapi.importer.sources.base import ImportSource
+
+
+class ExampleImportSource(ImportSource):
+    name = "example"
+
+    def load(self, path: Path) -> list[RawPollImport]:
+        ...
+```
+
+Then register it in `src/pollingapi/importer/sources/__init__.py`.
+
+The source should return `RawPollImport` objects. It should not insert database
+rows itself and should not call the cleaner directly. The runner owns those
+steps so all sources behave consistently.

--- a/src/pollingapi/importer/__init__.py
+++ b/src/pollingapi/importer/__init__.py
@@ -1,0 +1,6 @@
+"""File import support for pollingAPI."""
+
+from pollingapi.importer.runner import IMPORTS_DIR, ImportRunner
+from pollingapi.importer.schemas import ImportResult, ImportStats, RawPollImport
+
+__all__ = ["IMPORTS_DIR", "ImportResult", "ImportRunner", "ImportStats", "RawPollImport"]

--- a/src/pollingapi/importer/__init__.py
+++ b/src/pollingapi/importer/__init__.py
@@ -1,6 +1,15 @@
 """File import support for pollingAPI."""
 
+from pollingapi.importer.download import DEFAULT_MANIFEST, download_from_manifest
 from pollingapi.importer.runner import IMPORTS_DIR, ImportRunner
 from pollingapi.importer.schemas import ImportResult, ImportStats, RawPollImport
 
-__all__ = ["IMPORTS_DIR", "ImportResult", "ImportRunner", "ImportStats", "RawPollImport"]
+__all__ = [
+    "DEFAULT_MANIFEST",
+    "IMPORTS_DIR",
+    "ImportResult",
+    "ImportRunner",
+    "ImportStats",
+    "RawPollImport",
+    "download_from_manifest",
+]

--- a/src/pollingapi/importer/download.py
+++ b/src/pollingapi/importer/download.py
@@ -1,0 +1,140 @@
+"""Download helpers for importer input files."""
+
+import shlex
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+import httpx
+
+from pollingapi.core import PROJECT_ROOT
+from pollingapi.importer.runner import IMPORTS_DIR
+
+DEFAULT_MANIFEST = PROJECT_ROOT / "import_urls.txt"
+
+
+@dataclass(frozen=True)
+class DownloadSpec:
+    """One file download declared in the import URL manifest."""
+
+    destination: Path
+    url: str
+
+
+@dataclass(frozen=True)
+class DownloadResult:
+    """Result for one attempted download."""
+
+    destination: Path
+    url: str
+    downloaded: bool
+    bytes_written: int
+
+
+Downloader = Callable[[str, Path, float], int]
+
+
+def read_download_manifest(path: Path = DEFAULT_MANIFEST) -> list[DownloadSpec]:
+    """Read import download specs from a text manifest.
+
+    Supported line formats:
+        filename.xlsx https://example.com/file.xlsx
+        https://example.com/file.xlsx
+
+    Blank lines and lines starting with ``#`` are ignored.
+    """
+    specs: list[DownloadSpec] = []
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        specs.append(_parse_manifest_line(line, line_number))
+    return specs
+
+
+def download_from_manifest(
+    manifest_path: Path = DEFAULT_MANIFEST,
+    imports_dir: Path = IMPORTS_DIR,
+    force: bool = False,
+    timeout: float = 60.0,
+    downloader: Downloader | None = None,
+) -> list[DownloadResult]:
+    """Download all files declared in the manifest into the imports directory."""
+    imports_dir.mkdir(parents=True, exist_ok=True)
+    download = downloader or download_url
+    results: list[DownloadResult] = []
+
+    for spec in read_download_manifest(manifest_path):
+        destination = _resolve_destination(imports_dir, spec.destination)
+        if destination.exists() and not force:
+            results.append(
+                DownloadResult(
+                    destination=destination,
+                    url=spec.url,
+                    downloaded=False,
+                    bytes_written=destination.stat().st_size,
+                )
+            )
+            continue
+
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        bytes_written = download(spec.url, destination, timeout)
+        results.append(
+            DownloadResult(
+                destination=destination,
+                url=spec.url,
+                downloaded=True,
+                bytes_written=bytes_written,
+            )
+        )
+
+    return results
+
+
+def download_url(url: str, destination: Path, timeout: float = 60.0) -> int:
+    """Download a URL to a local file and return the written byte count."""
+    bytes_written = 0
+    with httpx.stream("GET", url, timeout=timeout, follow_redirects=True) as response:
+        response.raise_for_status()
+        with destination.open("wb") as file:
+            for chunk in response.iter_bytes():
+                if not chunk:
+                    continue
+                file.write(chunk)
+                bytes_written += len(chunk)
+    return bytes_written
+
+
+def _parse_manifest_line(line: str, line_number: int) -> DownloadSpec:
+    parts = shlex.split(line)
+    if len(parts) == 1:
+        url = parts[0]
+        destination = Path(_filename_from_url(url))
+    elif len(parts) == 2:
+        destination = Path(parts[0])
+        url = parts[1]
+    else:
+        raise ValueError(
+            f"Invalid import URL manifest line {line_number}: expected URL or 'filename URL'"
+        )
+
+    if destination.is_absolute() or ".." in destination.parts:
+        raise ValueError(f"Invalid destination on manifest line {line_number}: {destination}")
+
+    return DownloadSpec(destination=destination, url=url)
+
+
+def _filename_from_url(url: str) -> str:
+    parsed = urlparse(url)
+    filename = Path(parsed.path).name
+    if not filename:
+        raise ValueError(f"Cannot infer filename from URL: {url}")
+    return filename
+
+
+def _resolve_destination(imports_dir: Path, destination: Path) -> Path:
+    resolved = imports_dir / destination
+    if not resolved.resolve().is_relative_to(imports_dir.resolve()):
+        raise ValueError(f"Download destination escapes imports directory: {destination}")
+    return resolved

--- a/src/pollingapi/importer/formats/csv.py
+++ b/src/pollingapi/importer/formats/csv.py
@@ -1,0 +1,20 @@
+"""CSV loading helpers for imports."""
+
+import csv
+from pathlib import Path
+
+
+def read_csv_rows(
+    path: Path, delimiter: str = ",", encoding: str = "utf-8-sig"
+) -> list[dict[str, str]]:
+    """Read a CSV file into stripped dictionaries."""
+    with path.open("r", encoding=encoding, newline="") as file:
+        reader = csv.DictReader(file, delimiter=delimiter)
+        return [
+            {
+                (key or "").strip(): (value or "").strip()
+                for key, value in row.items()
+                if key and key.strip()
+            }
+            for row in reader
+        ]

--- a/src/pollingapi/importer/formats/xlsx.py
+++ b/src/pollingapi/importer/formats/xlsx.py
@@ -1,0 +1,33 @@
+"""XLSX loading helpers for imports."""
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+def read_xlsx_rows(
+    path: Path,
+    sheet_name: str | int = 0,
+    header: int = 0,
+) -> list[dict[str, str]]:
+    """Read an XLSX worksheet into stripped dictionaries."""
+    frame = pd.read_excel(path, sheet_name=sheet_name, header=header, dtype=object)
+    frame = frame.where(pd.notna(frame), "")
+
+    rows: list[dict[str, str]] = []
+    for row in frame.to_dict(orient="records"):
+        rows.append(
+            {
+                _stringify(key).strip(): _stringify(value).strip()
+                for key, value in row.items()
+                if _stringify(key).strip()
+            }
+        )
+    return rows
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)

--- a/src/pollingapi/importer/insertion.py
+++ b/src/pollingapi/importer/insertion.py
@@ -1,0 +1,62 @@
+"""Insertion helpers for imported raw polls."""
+
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from pollingapi.models import RawPoll
+
+DEDUP_KEYS = (
+    "publish_date",
+    "survey_date_start",
+    "survey_date_end",
+    "respondents",
+    "zeitraum",
+    "parties",
+    "institute_id",
+    "provider",
+    "tasker",
+    "source",
+    "scope",
+    "election_id",
+    "method_id",
+    "worker",
+    "survey_type",
+)
+
+
+def raw_poll_exists(db: Session, raw_dict: dict[str, Any]) -> bool:
+    """Return True when an equivalent raw poll already exists."""
+    query = db.query(RawPoll)
+    for key in DEDUP_KEYS:
+        column = getattr(RawPoll, key)
+        value = raw_dict.get(key)
+        query = query.filter(column.is_(None)) if value is None else query.filter(column == value)
+    return query.first() is not None
+
+
+def insert_raw_polls(
+    db: Session,
+    raw_polls: list[dict[str, Any]],
+    dry_run: bool = False,
+) -> tuple[int, int]:
+    """Insert raw poll dictionaries, skipping duplicates."""
+    inserted = 0
+    skipped = 0
+    seen_keys: set[tuple[Any, ...]] = set()
+
+    for raw_dict in raw_polls:
+        dedup_key = tuple(raw_dict.get(key) for key in DEDUP_KEYS)
+        if dedup_key in seen_keys or raw_poll_exists(db, raw_dict):
+            skipped += 1
+            continue
+        seen_keys.add(dedup_key)
+        db.add(RawPoll(**raw_dict))
+        inserted += 1
+
+    if dry_run:
+        db.rollback()
+    elif inserted:
+        db.commit()
+
+    return inserted, skipped

--- a/src/pollingapi/importer/runner.py
+++ b/src/pollingapi/importer/runner.py
@@ -1,0 +1,90 @@
+"""Importer orchestration."""
+
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+from pollingapi.cleaner import run_cleaning_pipeline
+from pollingapi.core import PROJECT_ROOT
+from pollingapi.importer.insertion import insert_raw_polls
+from pollingapi.importer.schemas import ImportResult, ImportStats, RawPollImport
+from pollingapi.importer.sources import get_source, list_sources
+from pollingapi.logging_config import get_logger
+
+IMPORTS_DIR = PROJECT_ROOT / "imports"
+logger = get_logger(__name__)
+
+
+class ImportRunner:
+    """Run file imports into polls_raw and optionally clean them."""
+
+    def __init__(self, db: Session, imports_dir: Path = IMPORTS_DIR):
+        self.db = db
+        self.imports_dir = imports_dir
+
+    def resolve_path(self, path: Path | str) -> Path:
+        """Resolve import paths relative to the top-level imports directory."""
+        candidate = Path(path)
+        if not candidate.is_absolute():
+            candidate = self.imports_dir / candidate
+        return candidate
+
+    def list_sources(self) -> list[str]:
+        """List available importer sources."""
+        return list_sources()
+
+    def preview(self, source_name: str, path: Path | str, limit: int = 10) -> list[RawPollImport]:
+        """Load a file and return the first parsed rows without inserting."""
+        source = get_source(source_name)
+        resolved_path = self._validated_path(path)
+        return source.load(resolved_path)[:limit]
+
+    def run(
+        self,
+        source_name: str,
+        path: Path | str,
+        clean: bool = False,
+        dry_run: bool = False,
+    ) -> ImportResult:
+        """Import file rows into polls_raw."""
+        source = get_source(source_name)
+        resolved_path = self._validated_path(path)
+        stats = ImportStats()
+
+        try:
+            rows = source.load(resolved_path)
+        except Exception as exc:
+            stats.errors = 1
+            stats.error_messages.append(str(exc))
+            return ImportResult(source=source_name, path=str(resolved_path), stats=stats)
+
+        stats.parsed = len(rows)
+        raw_polls = [row.to_raw_dict() for row in rows]
+        stats.inserted, stats.skipped = insert_raw_polls(self.db, raw_polls, dry_run=dry_run)
+
+        cleaning_stats = None
+        if clean and not dry_run and stats.inserted:
+            cleaning_stats = run_cleaning_pipeline(self.db)
+
+        logger.info(
+            "Import complete: source=%s path=%s parsed=%s inserted=%s skipped=%s",
+            source_name,
+            resolved_path,
+            stats.parsed,
+            stats.inserted,
+            stats.skipped,
+        )
+        return ImportResult(
+            source=source_name,
+            path=str(resolved_path),
+            stats=stats,
+            cleaning_stats=cleaning_stats,
+        )
+
+    def _validated_path(self, path: Path | str) -> Path:
+        resolved_path = self.resolve_path(path)
+        if not resolved_path.exists():
+            raise FileNotFoundError(f"Import file not found: {resolved_path}")
+        if not resolved_path.is_file():
+            raise ValueError(f"Import path is not a file: {resolved_path}")
+        return resolved_path

--- a/src/pollingapi/importer/schemas.py
+++ b/src/pollingapi/importer/schemas.py
@@ -1,0 +1,78 @@
+"""Schemas and result types for file imports."""
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+def _blank_to_none(value: Any) -> Any:
+    if isinstance(value, str):
+        value = value.strip()
+        return value or None
+    return value
+
+
+class RawPollImport(BaseModel):
+    """Importer-facing representation of one row destined for polls_raw."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    publish_date: str | None = None
+    survey_date_start: str | None = None
+    survey_date_end: str | None = None
+    respondents: str | None = None
+    zeitraum: str | None = Field(default=None, alias="Zeitraum")
+    parties: dict[str, str] | str
+    institute_id: str | None = None
+    provider: str | None = None
+    tasker: str | None = None
+    source: str | None = "csv_import"
+    scope: str | None = None
+    election_id: str | None = None
+    method_id: str | None = "99"
+    worker: str | None = None
+    survey_type: str | None = None
+    date_downloaded: str | None = None
+    pipeline_run_id: str | None = None
+
+    @field_validator("*", mode="before")
+    @classmethod
+    def _normalize_blank_strings(cls, value: Any) -> Any:
+        return _blank_to_none(value)
+
+    def to_raw_dict(self) -> dict[str, Any]:
+        """Return a dict suitable for constructing a RawPoll."""
+        data = self.model_dump(by_alias=False)
+        parties = data["parties"]
+        if isinstance(parties, dict):
+            parties = {key: str(value) for key, value in parties.items() if str(value).strip()}
+            data["parties"] = json.dumps(parties, sort_keys=True)
+
+        if not data.get("date_downloaded"):
+            data["date_downloaded"] = datetime.now().isoformat()
+
+        return data
+
+
+@dataclass
+class ImportStats:
+    """High-level import counters."""
+
+    parsed: int = 0
+    inserted: int = 0
+    skipped: int = 0
+    errors: int = 0
+    error_messages: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ImportResult:
+    """Result of an import run."""
+
+    source: str
+    path: str
+    stats: ImportStats
+    cleaning_stats: dict[str, int] | None = None

--- a/src/pollingapi/importer/sources/__init__.py
+++ b/src/pollingapi/importer/sources/__init__.py
@@ -1,0 +1,22 @@
+"""Built-in import source registry."""
+
+from pollingapi.importer.sources.base import ImportSource
+from pollingapi.importer.sources.csv import CsvImportSource
+
+SOURCES: dict[str, type[ImportSource]] = {
+    CsvImportSource.name: CsvImportSource,
+    "manual_csv": CsvImportSource,
+}
+
+
+def get_source(name: str) -> ImportSource:
+    """Return a configured import source by name."""
+    try:
+        return SOURCES[name]()
+    except KeyError as exc:
+        raise ValueError(f"Import source '{name}' not found") from exc
+
+
+def list_sources() -> list[str]:
+    """List available import source names."""
+    return sorted(SOURCES)

--- a/src/pollingapi/importer/sources/__init__.py
+++ b/src/pollingapi/importer/sources/__init__.py
@@ -2,9 +2,11 @@
 
 from pollingapi.importer.sources.base import ImportSource
 from pollingapi.importer.sources.csv import CsvImportSource
+from pollingapi.importer.sources.kayser_rehmert import KayserRehmertImportSource
 
 SOURCES: dict[str, type[ImportSource]] = {
     CsvImportSource.name: CsvImportSource,
+    KayserRehmertImportSource.name: KayserRehmertImportSource,
     "manual_csv": CsvImportSource,
 }
 

--- a/src/pollingapi/importer/sources/base.py
+++ b/src/pollingapi/importer/sources/base.py
@@ -1,0 +1,16 @@
+"""Base classes for import sources."""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from pollingapi.importer.schemas import RawPollImport
+
+
+class ImportSource(ABC):
+    """Convert source-specific files into raw poll import rows."""
+
+    name: str
+
+    @abstractmethod
+    def load(self, path: Path) -> list[RawPollImport]:
+        """Load import rows from a file."""

--- a/src/pollingapi/importer/sources/csv.py
+++ b/src/pollingapi/importer/sources/csv.py
@@ -1,0 +1,82 @@
+"""Generic CSV import source."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pollingapi.importer.formats.csv import read_csv_rows
+from pollingapi.importer.schemas import RawPollImport
+from pollingapi.importer.sources.base import ImportSource
+
+FIELD_ALIASES = {
+    "publish_date": ("publish_date", "datum", "date", "published_at"),
+    "survey_date_start": ("survey_date_start", "survey_start", "start_date"),
+    "survey_date_end": ("survey_date_end", "survey_end", "end_date"),
+    "respondents": ("respondents", "befragte", "sample_size"),
+    "zeitraum": ("zeitraum", "timeframe", "survey_period"),
+    "institute_id": ("institute_id", "institut", "institute"),
+    "provider": ("provider", "data_source", "source_provider"),
+    "tasker": ("tasker", "auftraggeber", "commissioner"),
+    "source": ("source",),
+    "scope": ("scope", "state", "land"),
+    "election_id": ("election_id", "election", "election_type"),
+    "method_id": ("method_id", "method", "survey_method"),
+    "worker": ("worker",),
+    "survey_type": ("survey_type",),
+    "date_downloaded": ("date_downloaded", "scraped_at", "imported_at"),
+    "pipeline_run_id": ("pipeline_run_id",),
+}
+
+PARTIES_COLUMNS = ("parties", "results")
+RESERVED_COLUMNS = {alias for aliases in FIELD_ALIASES.values() for alias in aliases}
+RESERVED_COLUMNS.update(PARTIES_COLUMNS)
+
+
+class CsvImportSource(ImportSource):
+    """Import CSV files with raw-poll-like columns and party result columns."""
+
+    name = "csv"
+
+    def load(self, path: Path) -> list[RawPollImport]:
+        return [self._row_to_import(row) for row in read_csv_rows(path)]
+
+    def _row_to_import(self, row: dict[str, str]) -> RawPollImport:
+        normalized_row = {key.strip().lower(): value for key, value in row.items()}
+        data: dict[str, Any] = {
+            field: self._first_value(normalized_row, aliases)
+            for field, aliases in FIELD_ALIASES.items()
+        }
+        data["source"] = data.get("source") or "csv_import"
+        data["method_id"] = data.get("method_id") or "99"
+        data["worker"] = data.get("worker") or f"import:{self.name}"
+        data["parties"] = self._extract_parties(row)
+        return RawPollImport.model_validate(data)
+
+    @staticmethod
+    def _first_value(row: dict[str, str], aliases: tuple[str, ...]) -> str | None:
+        for alias in aliases:
+            value = row.get(alias)
+            if value:
+                return value
+        return None
+
+    @staticmethod
+    def _extract_parties(row: dict[str, str]) -> dict[str, str]:
+        normalized_row = {key.strip().lower(): value for key, value in row.items()}
+        for column in PARTIES_COLUMNS:
+            value = normalized_row.get(column)
+            if not value:
+                continue
+            parsed = json.loads(value)
+            if not isinstance(parsed, dict):
+                raise ValueError(f"{column} must contain a JSON object")
+            return {str(key): str(result) for key, result in parsed.items()}
+
+        parties = {
+            key: value
+            for key, value in row.items()
+            if key.strip().lower() not in RESERVED_COLUMNS and value
+        }
+        if not parties:
+            raise ValueError("CSV row does not contain party result columns")
+        return parties

--- a/src/pollingapi/importer/sources/kayser_rehmert.py
+++ b/src/pollingapi/importer/sources/kayser_rehmert.py
@@ -1,0 +1,157 @@
+"""Importer for Kayser/Rehmert coalition inclusion probability polling data."""
+
+import re
+from collections import defaultdict
+from collections.abc import Iterable
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from pollingapi.importer.schemas import RawPollImport
+from pollingapi.importer.sources.base import ImportSource
+
+COUNTRY_ISO3C = "DEU"
+PROVIDER = "Kayser/Rehmert"
+WORKER = "import:kayser_rehmert"
+SOURCE = "xlsx_import:kayser_rehmert"
+
+GROUP_COLUMNS = ("survey_date", "institute")
+
+PARTY_NAME_MAP = {
+    "AfD": "AfD",
+    "BSW": "BSW",
+    "CDU/CSU": "CDU/CSU",
+    "FDP": "FDP",
+    "FW": "FW",
+    "Greens": "Grüne",
+    "Other": "Sonstige",
+    "PDS/Linke": "Linke",
+    "SPD": "SPD",
+}
+
+INSTITUTE_NAME_MAP = {
+    "Emnid": "Verian (Emnid)",
+    "Infratest dimap": "Infratest Dimap",
+    "Pollytix": "pollytix",
+    "Wahlkreisprognose": "Institut Wahlkreisprognose",
+}
+
+
+class KayserRehmertImportSource(ImportSource):
+    """Load Germany-only poll rows from the Kayser/Rehmert XLSX file."""
+
+    name = "kayser_rehmert"
+
+    def load(self, path: Path) -> list[RawPollImport]:
+        frame = pd.read_excel(path, sheet_name="Table1", dtype=object)
+        frame = _normalize_frame(frame)
+        frame = frame[
+            frame["country_iso3c"].eq(COUNTRY_ISO3C) & frame["original_date"].eq("1")
+        ].copy()
+
+        imports: list[RawPollImport] = []
+        for _, group in frame.groupby(list(GROUP_COLUMNS), dropna=False, sort=False):
+            parties = _party_results(group.to_dict(orient="records"))
+            if parties is None:
+                continue
+
+            first = group.iloc[0].to_dict()
+            publish_date = _format_date(first["survey_date"])
+            if publish_date is None:
+                continue
+
+            imports.append(
+                RawPollImport(
+                    publish_date=publish_date,
+                    parties=parties,
+                    institute_id=_map_institute(first["institute"]),
+                    provider=PROVIDER,
+                    source=SOURCE,
+                    scope="Bund",
+                    election_id="Bundestagswahl",
+                    method_id="99",
+                    worker=WORKER,
+                )
+            )
+
+        return imports
+
+
+def _normalize_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    normalized = frame.copy()
+    for column in (
+        "country_iso3c",
+        "institute",
+        "original_date",
+        "party_name_short",
+        "poll",
+        "source",
+    ):
+        normalized[column] = normalized[column].fillna("").astype(str).str.strip()
+    return normalized
+
+
+def _party_results(rows: Iterable[dict[str, Any]]) -> dict[str, str] | None:
+    values_by_party: dict[str, list[str]] = defaultdict(list)
+    for row in rows:
+        party = PARTY_NAME_MAP.get(str(row["party_name_short"]).strip())
+        value = _format_number(row["poll"])
+        if party is None or value is None:
+            continue
+        values_by_party[party].append(value)
+
+    parties: dict[str, str] = {}
+    for party, values in values_by_party.items():
+        unique_values = sorted(set(values))
+        if len(unique_values) > 1:
+            return None
+        parties[party] = unique_values[0]
+
+    return parties or None
+
+
+def _format_date(value: Any) -> str | None:
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+
+    text = str(value).strip()
+    if not text:
+        return None
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}(?:\s+00:00:00)?", text):
+        return text[:10]
+
+    parsed = pd.to_datetime(text, dayfirst=True, errors="coerce")
+    if pd.isna(parsed):
+        return None
+    return parsed.date().isoformat()
+
+
+def _format_number(value: Any) -> str | None:
+    if value is None or pd.isna(value):
+        return None
+    text = str(value).strip().replace(",", ".")
+    if not text:
+        return None
+    number = float(text)
+    if number.is_integer():
+        return str(int(number))
+    return f"{number:.6f}".rstrip("0").rstrip(".")
+
+
+def _map_institute(value: Any) -> str:
+    name = str(value or "").strip()
+    if not name:
+        return "Unknown"
+
+    if " Archived " in name:
+        name = name.split(" Archived ", 1)[0].strip()
+    if name.endswith("(intermediate result)"):
+        name = name.removesuffix("(intermediate result)").strip()
+    if name.endswith("(MRP)"):
+        name = name.removesuffix("(MRP)").strip()
+
+    return INSTITUTE_NAME_MAP.get(name, name)

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -4,6 +4,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from pollingapi.database import Base
+from pollingapi.importer.download import download_from_manifest, read_download_manifest
 from pollingapi.importer.runner import ImportRunner
 from pollingapi.importer.sources import get_source, list_sources
 from pollingapi.models import Poll, PollResult, RawPoll
@@ -90,3 +91,67 @@ def test_import_runner_can_clean_imported_rows(tmp_path):
 
 def test_import_sources_are_listed():
     assert list_sources() == ["csv", "manual_csv"]
+
+
+def test_download_manifest_supports_explicit_and_inferred_filenames(tmp_path):
+    manifest = tmp_path / "import_urls.txt"
+    manifest.write_text(
+        "# comment\n"
+        "source/raw.xlsx https://example.com/data.xlsx\n"
+        "https://example.com/other.xlsx\n",
+        encoding="utf-8",
+    )
+
+    specs = read_download_manifest(manifest)
+
+    assert [spec.destination.as_posix() for spec in specs] == ["source/raw.xlsx", "other.xlsx"]
+    assert [spec.url for spec in specs] == [
+        "https://example.com/data.xlsx",
+        "https://example.com/other.xlsx",
+    ]
+
+
+def test_download_from_manifest_writes_below_imports_dir(tmp_path):
+    manifest = tmp_path / "import_urls.txt"
+    imports_dir = tmp_path / "imports"
+    manifest.write_text("source/raw.xlsx https://example.com/data.xlsx\n", encoding="utf-8")
+
+    def fake_downloader(url: str, destination, timeout: float) -> int:
+        assert url == "https://example.com/data.xlsx"
+        assert timeout == 12.0
+        destination.write_bytes(b"xlsx")
+        return 4
+
+    results = download_from_manifest(
+        manifest_path=manifest,
+        imports_dir=imports_dir,
+        timeout=12.0,
+        downloader=fake_downloader,
+    )
+
+    assert len(results) == 1
+    assert results[0].downloaded is True
+    assert results[0].destination == imports_dir / "source/raw.xlsx"
+    assert results[0].bytes_written == 4
+    assert (imports_dir / "source/raw.xlsx").read_bytes() == b"xlsx"
+
+
+def test_download_from_manifest_skips_existing_files(tmp_path):
+    manifest = tmp_path / "import_urls.txt"
+    imports_dir = tmp_path / "imports"
+    existing = imports_dir / "raw.xlsx"
+    imports_dir.mkdir()
+    existing.write_bytes(b"existing")
+    manifest.write_text("raw.xlsx https://example.com/data.xlsx\n", encoding="utf-8")
+
+    def failing_downloader(_url: str, _destination, _timeout: float) -> int:
+        raise AssertionError("downloader should not be called")
+
+    results = download_from_manifest(
+        manifest_path=manifest,
+        imports_dir=imports_dir,
+        downloader=failing_downloader,
+    )
+
+    assert results[0].downloaded is False
+    assert results[0].bytes_written == len(b"existing")

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,0 +1,92 @@
+"""Tests for file imports into raw polls."""
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from pollingapi.database import Base
+from pollingapi.importer.runner import ImportRunner
+from pollingapi.importer.sources import get_source, list_sources
+from pollingapi.models import Poll, PollResult, RawPoll
+
+
+def _session(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'polling.db'}")
+    Base.metadata.create_all(bind=engine)
+    return sessionmaker(bind=engine)()
+
+
+def test_csv_source_preserves_party_column_names(tmp_path):
+    path = tmp_path / "polls.csv"
+    path.write_text(
+        "publish_date,institut,scope,election_id,respondents,CDU/CSU,SPD\n"
+        "2024-06-01,Forsa,Bund,Bundestagswahl,1000,30,16\n",
+        encoding="utf-8",
+    )
+
+    rows = get_source("csv").load(path)
+
+    assert len(rows) == 1
+    assert rows[0].parties == {"CDU/CSU": "30", "SPD": "16"}
+    assert rows[0].to_raw_dict()["worker"] == "import:csv"
+
+
+def test_import_runner_inserts_and_dedupes_raw_rows(tmp_path):
+    session = _session(tmp_path)
+    path = tmp_path / "polls.csv"
+    path.write_text(
+        "publish_date,institut,scope,election_id,respondents,CDU/CSU,SPD\n"
+        "2024-06-01,Forsa,Bund,Bundestagswahl,1000,30,16\n",
+        encoding="utf-8",
+    )
+    runner = ImportRunner(session, imports_dir=tmp_path)
+
+    first = runner.run("csv", "polls.csv")
+    second = runner.run("csv", "polls.csv")
+
+    assert first.stats.parsed == 1
+    assert first.stats.inserted == 1
+    assert first.stats.skipped == 0
+    assert second.stats.inserted == 0
+    assert second.stats.skipped == 1
+    assert session.query(RawPoll).count() == 1
+
+
+def test_import_runner_dedupes_repeated_rows_in_same_file(tmp_path):
+    session = _session(tmp_path)
+    path = tmp_path / "polls.csv"
+    path.write_text(
+        "publish_date,institut,scope,election_id,respondents,CDU/CSU,SPD\n"
+        "2024-06-01,Forsa,Bund,Bundestagswahl,1000,30,16\n"
+        "2024-06-01,Forsa,Bund,Bundestagswahl,1000,30,16\n",
+        encoding="utf-8",
+    )
+    runner = ImportRunner(session, imports_dir=tmp_path)
+
+    result = runner.run("csv", "polls.csv")
+
+    assert result.stats.inserted == 1
+    assert result.stats.skipped == 1
+    assert session.query(RawPoll).count() == 1
+
+
+def test_import_runner_can_clean_imported_rows(tmp_path):
+    session = _session(tmp_path)
+    path = tmp_path / "polls.csv"
+    path.write_text(
+        "publish_date,institut,scope,election_id,respondents,CDU/CSU,SPD\n"
+        "2024-06-01,Forsa,Bund,Bundestagswahl,1000,30,16\n",
+        encoding="utf-8",
+    )
+    runner = ImportRunner(session, imports_dir=tmp_path)
+
+    result = runner.run("csv", path, clean=True)
+
+    assert result.stats.inserted == 1
+    assert result.cleaning_stats is not None
+    assert result.cleaning_stats["created"] == 1
+    assert session.query(Poll).count() == 1
+    assert {result.party_key for result in session.query(PollResult).all()} == {"CDU_CSU", "SPD"}
+
+
+def test_import_sources_are_listed():
+    assert list_sources() == ["csv", "manual_csv"]

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,5 +1,8 @@
 """Tests for file imports into raw polls."""
 
+import json
+
+import pandas as pd
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -90,7 +93,55 @@ def test_import_runner_can_clean_imported_rows(tmp_path):
 
 
 def test_import_sources_are_listed():
-    assert list_sources() == ["csv", "manual_csv"]
+    assert list_sources() == ["csv", "kayser_rehmert", "manual_csv"]
+
+
+def test_kayser_rehmert_source_filters_germany_original_polls_and_maps_columns(tmp_path):
+    path = tmp_path / "kayser.xlsx"
+    pd.DataFrame(
+        [
+            _kayser_row("Germany", "DEU", "Forsa", "2024-01-10", "1", "CDU/CSU", "30"),
+            _kayser_row("Germany", "DEU", "Forsa", "2024-01-10", "1", "Greens", "13,5"),
+            _kayser_row("Germany", "DEU", "Forsa", "2024-01-10", "1", "PDS/Linke", "4"),
+            _kayser_row("Germany", "DEU", "Forsa", "2024-01-10", "0", "SPD", "17"),
+            _kayser_row("Austria", "AUT", "Forsa", "2024-01-10", "1", "SPD", "20"),
+            _kayser_row("Germany", "DEU", "Wahlkreisprognose", "11.01.2024", "1", "SPD", "16"),
+        ]
+    ).to_excel(path, sheet_name="Table1", index=False)
+
+    rows = get_source("kayser_rehmert").load(path)
+
+    assert len(rows) == 2
+    first = rows[0].to_raw_dict()
+    assert first["publish_date"] == "2024-01-10"
+    assert first["institute_id"] == "Forsa"
+    assert first["provider"] == "Kayser/Rehmert"
+    assert first["source"] == "xlsx_import:kayser_rehmert"
+    assert first["scope"] == "Bund"
+    assert first["election_id"] == "Bundestagswahl"
+    assert json.loads(first["parties"]) == {
+        "CDU/CSU": "30",
+        "Grüne": "13.5",
+        "Linke": "4",
+    }
+    assert rows[1].publish_date == "2024-01-11"
+    assert rows[1].institute_id == "Institut Wahlkreisprognose"
+
+
+def test_kayser_rehmert_source_skips_conflicting_poll_groups(tmp_path):
+    path = tmp_path / "kayser.xlsx"
+    pd.DataFrame(
+        [
+            _kayser_row("Germany", "DEU", "INSA", "12.01.2024", "1", "CDU/CSU", "30"),
+            _kayser_row("Germany", "DEU", "INSA", "12.01.2024", "1", "CDU/CSU", "27"),
+            _kayser_row("Germany", "DEU", "INSA", "13.01.2024", "1", "SPD", "15"),
+        ]
+    ).to_excel(path, sheet_name="Table1", index=False)
+
+    rows = get_source("kayser_rehmert").load(path)
+
+    assert len(rows) == 1
+    assert rows[0].publish_date == "2024-01-13"
 
 
 def test_download_manifest_supports_explicit_and_inferred_filenames(tmp_path):
@@ -155,3 +206,28 @@ def test_download_from_manifest_skips_existing_files(tmp_path):
 
     assert results[0].downloaded is False
     assert results[0].bytes_written == len(b"existing")
+
+
+def _kayser_row(
+    country: str,
+    country_iso3c: str,
+    institute: str,
+    survey_date: str,
+    original_date: str,
+    party_name_short: str,
+    poll: str,
+) -> dict[str, str | int]:
+    return {
+        "country": country,
+        "country_iso3c": country_iso3c,
+        "year": 2024,
+        "institute": institute,
+        "survey_date": survey_date,
+        "month": 1,
+        "original_date": original_date,
+        "party_id": "",
+        "party_name_english": "",
+        "party_name_short": party_name_short,
+        "poll": poll,
+        "source": "fixture",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -348,6 +348,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.135.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1102,6 +1111,18 @@ wheels = [
 ]
 
 [[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1216,6 +1237,7 @@ dependencies = [
     { name = "mkdocs-material" },
     { name = "mkdocs-minify-plugin" },
     { name = "numpy" },
+    { name = "openpyxl" },
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "pydantic" },
@@ -1261,6 +1283,7 @@ requires-dist = [
     { name = "mkdocs-minify-plugin", specifier = ">=0.8.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
     { name = "numpy", specifier = ">=2.0.0" },
+    { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pandas", specifier = ">=2.2.0" },
     { name = "pyarrow", specifier = ">=23.0.0" },
     { name = "pydantic", specifier = ">=2.9.0" },


### PR DESCRIPTION
This Feature resolves issue #45 by creating a reusable pipe for adding in sources from various file formats. The data gets written to the polls_raw table and the cleaned in the normal cleaner step. that results in a proper integration with the fingerprint/ deduplication logic as well as the validation schema. 

The PR also includes a manifest where urls can be placed to download data.
The data and integration can be done in `src/pollingapi/importer/sources`
File loaders are included as well. 
README provides more details on the technical implementation as well as the workflow for new data