### PR TITLE
feat(notifications): add RSS feed for pipeline runs

### DIFF
--- a/src/pollingapi/api/v2.py
+++ b/src/pollingapi/api/v2.py
@@ -1011,6 +1011,18 @@ def download_file(filename: str):
     return FileResponse(path=path, filename=filename, media_type=media_type)
 
 
+@router.get("/pipeline-notifications.rss", include_in_schema=False)
+def pipeline_notifications_feed():
+    """Serve the pipeline notification RSS feed."""
+    path = settings.rss_feed_path
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="RSS feed not found")
+    return FileResponse(
+        path=path,
+        media_type="application/rss+xml",
+    )
+
+
 def _format_size(size_bytes: int | float) -> str:
     size = float(size_bytes)
     for unit in ["B", "KB", "MB", "GB"]:

--- a/src/pollingapi/core/__init__.py
+++ b/src/pollingapi/core/__init__.py
@@ -60,6 +60,8 @@ class Settings(BaseSettings):
     ntfy_topic_title: str = "pollingAPI"
     # Set SLACK_WEBHOOK_URL to enable Slack notifications
     slack_webhook_url: str | None = None
+    # Set RSS_FEED_PATH to override the pipeline notification RSS file
+    rss_feed_path: Path = DATA_DIR / "export" / "pipeline-notifications.rss"
 
     # Data Paths
     data_dir: Path = DATA_DIR

--- a/src/pollingapi/notifications/__init__.py
+++ b/src/pollingapi/notifications/__init__.py
@@ -6,6 +6,7 @@ Public API
 - :class:`BaseNotifier` — abstract base for notification backends
 - :class:`NotificationManager` — fan-out dispatcher
 - :class:`NtfyNotifier` — ntfy.sh push notification backend
+- :class:`RssNotifier` — local RSS feed notification backend
 - :func:`create_notification_manager` — factory that builds a configured manager
 
 Example
@@ -24,6 +25,7 @@ from __future__ import annotations
 from .base import BaseNotifier, PipelineRunResult, ScraperRunResult
 from .manager import NotificationManager
 from .ntfy import NtfyNotifier
+from .rss_notification import RssNotifier
 from .slack import SlackNotifier
 
 
@@ -34,6 +36,7 @@ def create_notification_manager() -> NotificationManager:
 
     - :class:`NtfyNotifier` if ``NTFY_URL`` is set in the environment / ``.env``.
     - :class:`SlackNotifier` if ``SLACK_WEBHOOK_URL`` is set.
+    - :class:`RssNotifier` for the local notification feed.
 
     Returns:
         A ready-to-use :class:`NotificationManager`.
@@ -54,12 +57,21 @@ def create_notification_manager() -> NotificationManager:
     if settings.slack_webhook_url:
         manager.register(SlackNotifier(webhook_url=settings.slack_webhook_url))
 
+    if settings.rss_feed_path:
+        manager.register(
+            RssNotifier(
+                feed_path=settings.rss_feed_path,
+                title_prefix=settings.ntfy_topic_title,
+            )
+        )
+
     return manager
 
 
 __all__ = [
     "BaseNotifier",
     "NtfyNotifier",
+    "RssNotifier",
     "SlackNotifier",
     "NotificationManager",
     "PipelineRunResult",

--- a/src/pollingapi/notifications/rss_notification.py
+++ b/src/pollingapi/notifications/rss_notification.py
@@ -1,0 +1,110 @@
+"""RSS notification backend.
+
+Writes pipeline run summaries to a local RSS XML file. This is useful when the
+pipeline should publish notification history without sending push messages.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC
+from email.utils import format_datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+from xml.etree import ElementTree as ET
+
+from pollingapi.logging_config import get_logger
+
+from .base import BaseNotifier
+from .ntfy import _format_message
+
+if TYPE_CHECKING:
+    from .base import PipelineRunResult
+
+logger = get_logger(__name__)
+
+
+class RssNotifier(BaseNotifier):
+    """Write pipeline run summaries to an RSS feed file."""
+
+    def __init__(
+        self,
+        feed_path: str | Path,
+        title_prefix: str = "pollingAPI",
+        feed_link: str = "/v2/pipeline-notifications.rss",
+        max_items: int = 50,
+    ) -> None:
+        self._feed_path = Path(feed_path)
+        self._title_prefix = title_prefix
+        self._feed_link = feed_link
+        self._max_items = max_items
+
+    def is_configured(self) -> bool:
+        return bool(self._feed_path)
+
+    def notify(self, result: PipelineRunResult) -> None:
+        if not self.is_configured():
+            logger.debug("RssNotifier: no feed path configured, skipping")
+            return
+
+        try:
+            self._feed_path.parent.mkdir(parents=True, exist_ok=True)
+            root, channel = self._load_feed()
+            self._prepend_item(channel, result)
+            self._trim_items(channel)
+            ET.ElementTree(root).write(
+                self._feed_path,
+                encoding="utf-8",
+                xml_declaration=True,
+            )
+            logger.info(f"RssNotifier: wrote notification feed to {self._feed_path}")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(f"RssNotifier: unexpected error - {exc}")
+
+    def _load_feed(self) -> tuple[ET.Element, ET.Element]:
+        if self._feed_path.exists():
+            root = ET.parse(self._feed_path).getroot()
+            channel = root.find("channel")
+            if channel is not None:
+                return root, channel
+
+        root = ET.Element("rss", version="2.0")
+        channel = ET.SubElement(root, "channel")
+        ET.SubElement(channel, "title").text = f"{self._title_prefix} Pipeline Notifications"
+        ET.SubElement(channel, "link").text = self._feed_link
+        ET.SubElement(channel, "description").text = "Pipeline run notifications from pollingAPI."
+        return root, channel
+
+    def _prepend_item(self, channel: ET.Element, result: PipelineRunResult) -> None:
+        for item in list(channel.findall("item")):
+            guid = item.findtext("guid")
+            if guid == result.run_id:
+                channel.remove(item)
+
+        status = "SUCCESS" if result.success else "FAILURE"
+        if result.success and (
+            result.zero_poll_workers or result.validation_status in {"warn", "fail"}
+        ):
+            status = "WARNING"
+
+        item = ET.Element("item")
+        ET.SubElement(item, "title").text = f"[{self._title_prefix}] Pipeline {status}"
+        ET.SubElement(item, "link").text = self._feed_link
+        ET.SubElement(item, "guid", isPermaLink="false").text = result.run_id
+        finished_at = result.finished_at
+        if finished_at.tzinfo is None:
+            finished_at = finished_at.replace(tzinfo=UTC)
+        ET.SubElement(item, "pubDate").text = format_datetime(finished_at)
+        ET.SubElement(item, "description").text = _format_message(result, self._title_prefix)
+        channel.insert(_first_item_index(channel), item)
+
+    def _trim_items(self, channel: ET.Element) -> None:
+        items = channel.findall("item")
+        for item in items[self._max_items :]:
+            channel.remove(item)
+
+
+def _first_item_index(channel: ET.Element) -> int:
+    for index, child in enumerate(list(channel)):
+        if child.tag == "item":
+            return index
+    return len(channel)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -240,6 +240,18 @@ class TestV2Endpoints:
         assert "/v2/archives/{filename}" in route_paths
         assert "/v2/archives/{filename}/download" in route_paths
 
+    def test_v2_pipeline_notifications_rss_is_hidden_from_docs(self, client, tmp_path, monkeypatch):
+        """Test the notification RSS feed is served but hidden from OpenAPI."""
+        feed_path = tmp_path / "pipeline-notifications.rss"
+        feed_path.write_text("<?xml version='1.0'?><rss version='2.0' />", encoding="utf-8")
+        monkeypatch.setattr("pollingapi.core.settings.rss_feed_path", feed_path)
+
+        response = client.get("/v2/pipeline-notifications.rss")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/rss+xml")
+        assert "/v2/pipeline-notifications.rss" not in client.get("/openapi.json").json()["paths"]
+
     def test_openapi_shows_v2_but_hides_v1(self, client):
         """Test public OpenAPI docs show v2 while keeping v1 hidden."""
         response = client.get("/openapi.json")

--- a/tests/test_rss_notification.py
+++ b/tests/test_rss_notification.py
@@ -1,0 +1,54 @@
+"""Tests for RSS notification output."""
+
+from __future__ import annotations
+
+import datetime as dt
+from xml.etree import ElementTree as ET
+
+from pollingapi.notifications import PipelineRunResult
+from pollingapi.notifications.rss_notification import RssNotifier
+
+
+def test_rss_notifier_writes_pipeline_summary_feed(tmp_path) -> None:
+    feed_path = tmp_path / "notifications.xml"
+    notifier = RssNotifier(feed_path=feed_path, title_prefix="pollingAPI", max_items=1)
+
+    old = _result("old-run", dt.datetime(2026, 7, 29, 12, 0, 0))
+    new = _result("new-run", dt.datetime(2026, 7, 30, 12, 0, 0))
+    notifier.notify(old)
+    notifier.notify(new)
+
+    root = ET.parse(feed_path).getroot()
+    channel = root.find("channel")
+    assert channel is not None
+    items = channel.findall("item")
+    assert len(items) == 1
+    assert items[0].findtext("guid") == "new-run"
+    assert items[0].findtext("title") == "[pollingAPI] Pipeline SUCCESS"
+    description = items[0].findtext("description") or ""
+    assert "--- Scraper ---" in description
+    assert "--- ETL Cleaner ---" in description
+    assert "--- Validation ---" in description
+    assert "--- Export ---" in description
+
+
+def _result(run_id: str, finished_at: dt.datetime) -> PipelineRunResult:
+    return PipelineRunResult(
+        run_id=run_id,
+        started_at=finished_at - dt.timedelta(minutes=1),
+        finished_at=finished_at,
+        success=True,
+        scrapers_run=2,
+        scrapers_succeeded=2,
+        total_scraped_polls=3,
+        etl_processed=3,
+        etl_created=2,
+        etl_updated=1,
+        validation_status="pass",
+        validation_total_polls=3,
+        validation_valid_polls=3,
+        validation_valid_share=1.0,
+        export_polls=3,
+        export_poll_results=12,
+        export_raw_polls=4,
+    )


### PR DESCRIPTION
This PR adds an RSS feed to get info on the latest pipeline run. This feed mirrors our other notifications