### PR TITLE
Map DAWUM Parliament_ID to state scopes

### DIFF
--- a/src/pollingapi/scraper/dawum.py
+++ b/src/pollingapi/scraper/dawum.py
@@ -277,9 +277,11 @@ class DawumScraper:
             skipped = 0
             for payload in payloads:
                 existing = self._find_existing_raw(payload)
-                needs_write = existing is None or existing.scope != payload.get(
-                    "scope"
-                ) or existing.election_id != payload.get("election_id")
+                needs_write = (
+                    existing is None
+                    or existing.scope != payload.get("scope")
+                    or existing.election_id != payload.get("election_id")
+                )
                 if needs_write:
                     new_or_fixable.append(payload)
                 else:

--- a/src/pollingapi/scraper/dawum.py
+++ b/src/pollingapi/scraper/dawum.py
@@ -12,14 +12,35 @@ from pollingapi.core import DATA_DIR
 from pollingapi.logging_config import get_logger
 from pollingapi.models import RawPoll
 from pollingapi.scraper.context import RunContext
+from pollingapi.scraper.dawum_parliaments import (
+    UnknownDawumParliamentError,
+    map_dawum_parliament,
+)
 from pollingapi.scraper.schemas import filter_poll_payloads
+
+# Identity for DAWUM re-ingest. Scope/election_id are intentionally excluded so
+# correcting a mis-scoped row updates in place instead of inserting a duplicate.
+_DAWUM_IDENTITY_KEYS = (
+    "publish_date",
+    "survey_date_start",
+    "survey_date_end",
+    "respondents",
+    "zeitraum",
+    "parties",
+    "institute_id",
+    "provider",
+    "tasker",
+    "source",
+    "method_id",
+    "worker",
+    "survey_type",
+)
 
 
 class DawumScraper:
     """Scraper for DAWUM API data."""
 
     DATA_SOURCE = "DAWUM"
-    SCOPE = "federal"
     WORKER = "dawum"
     REQUEST_TIMEOUT = 30
 
@@ -63,9 +84,12 @@ class DawumScraper:
         # Merge with parliaments
         if not parliaments.empty:
             parliaments_reset = parliaments.reset_index().rename(columns={"index": "Parliament_ID"})
+            keep = ["Parliament_ID", "Shortcut"]
+            if "Election" in parliaments_reset.columns:
+                keep.append("Election")
             df = df.merge(
-                parliaments_reset[["Parliament_ID", "Shortcut"]].rename(
-                    columns={"Shortcut": "Parliament"}
+                parliaments_reset[keep].rename(
+                    columns={"Shortcut": "Parliament", "Election": "Election_Name"}
                 ),
                 on="Parliament_ID",
                 how="left",
@@ -142,11 +166,39 @@ class DawumScraper:
         }
         df_mapped = df_mapped.rename(columns=column_mapping)
 
+        scopes: list[str] = []
+        election_ids: list[str] = []
+        skipped_unknown = 0
+        keep_mask: list[bool] = []
+        for _, row in df_mapped.iterrows():
+            try:
+                mapping = map_dawum_parliament(
+                    row.get("Parliament_ID"),
+                    shortcut=row.get("Parliament"),
+                    election=row.get("Election_Name"),
+                )
+            except UnknownDawumParliamentError as exc:
+                skipped_unknown += 1
+                self.logger.warning("Skipping DAWUM survey with unmapped parliament: %s", exc)
+                keep_mask.append(False)
+                scopes.append("")
+                election_ids.append("")
+                continue
+            keep_mask.append(True)
+            scopes.append(mapping.scope)
+            election_ids.append(mapping.election_id)
+
+        df_mapped["scope"] = scopes
+        df_mapped["election_id"] = election_ids
+        df_mapped = df_mapped.loc[keep_mask].copy()
+        if skipped_unknown:
+            self.logger.warning(
+                "Skipped %d DAWUM surveys with unknown parliament mapping", skipped_unknown
+            )
+
         # Add metadata
         df_mapped["provider"] = self.DATA_SOURCE
         df_mapped["source"] = "api"
-        df_mapped["scope"] = self.SCOPE
-        df_mapped["election_id"] = "Bundestagswahl"
         df_mapped["worker"] = self.WORKER
         df_mapped["zeitraum"] = None
         df_mapped["survey_type"] = None
@@ -205,59 +257,61 @@ class DawumScraper:
             pipeline_run_id=payload.get("pipeline_run_id"),
         )
 
-    def _check_duplicate(self, payload: dict[str, Any]) -> bool:
-        """Check if a poll already exists in the database."""
-        dedup_values = {
-            "publish_date": payload.get("publish_date"),
-            "survey_date_start": payload.get("survey_date_start"),
-            "survey_date_end": payload.get("survey_date_end"),
-            "respondents": payload.get("respondents"),
-            "zeitraum": payload.get("zeitraum"),
-            "parties": self._parties_json(payload.get("parties")),
-            "institute_id": payload.get("institute_id"),
-            "provider": payload.get("provider"),
-            "tasker": payload.get("tasker"),
-            "source": payload.get("source"),
-            "scope": payload.get("scope"),
-            "election_id": payload.get("election_id"),
-            "method_id": payload.get("method_id"),
-            "worker": payload.get("worker"),
-            "survey_type": payload.get("survey_type"),
-        }
-
+    def _find_existing_raw(self, payload: dict[str, Any]) -> RawPoll | None:
+        """Find an existing DAWUM raw row by survey identity (not scope)."""
         query = self.db.query(RawPoll)
-        for key, value in dedup_values.items():
+        for key in _DAWUM_IDENTITY_KEYS:
             column = getattr(RawPoll, key)
+            value = payload.get(key)
+            if key == "parties":
+                value = self._parties_json(value) if not isinstance(value, str) else value
             query = (
                 query.filter(column.is_(None)) if value is None else query.filter(column == value)
             )
-
-        return query.first() is not None
-
-    def _new_payloads(self, payloads: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Return only payloads that are not already present in polls_raw."""
-        return [payload for payload in payloads if not self._check_duplicate(payload)]
+        return query.first()
 
     def post_polls(self, payloads: list[dict[str, Any]]) -> int:
-        """Insert polls into database with deduplication."""
-        new_payloads = self._new_payloads(payloads)
-        skipped_count = len(payloads) - len(new_payloads)
-
+        """Insert polls into database with deduplication / scope correction."""
         if self.dry_run:
+            new_or_fixable = []
+            skipped = 0
+            for payload in payloads:
+                existing = self._find_existing_raw(payload)
+                needs_write = existing is None or existing.scope != payload.get(
+                    "scope"
+                ) or existing.election_id != payload.get("election_id")
+                if needs_write:
+                    new_or_fixable.append(payload)
+                else:
+                    skipped += 1
             self.logger.info(
-                f"[DRY RUN] Would insert {len(new_payloads)} DAWUM polls "
-                f"(skipped {skipped_count} duplicates)"
+                f"[DRY RUN] Would insert/update {len(new_or_fixable)} DAWUM polls "
+                f"(skipped {skipped} unchanged duplicates)"
             )
-            for payload in new_payloads[:3]:
+            for payload in new_or_fixable[:3]:
                 self.logger.info(f"  {payload}")
-            if len(new_payloads) > 3:
-                self.logger.info(f"  ... and {len(new_payloads) - 3} more")
-            return len(new_payloads)
+            if len(new_or_fixable) > 3:
+                self.logger.info(f"  ... and {len(new_or_fixable) - 3} more")
+            return len(new_or_fixable)
 
         inserted_count = 0
+        updated_count = 0
+        skipped_count = 0
 
-        for payload in new_payloads:
+        for payload in payloads:
             try:
+                existing = self._find_existing_raw(payload)
+                if existing is not None:
+                    scope = payload.get("scope")
+                    election_id = payload.get("election_id")
+                    if existing.scope != scope or existing.election_id != election_id:
+                        existing.scope = scope
+                        existing.election_id = election_id
+                        updated_count += 1
+                    else:
+                        skipped_count += 1
+                    continue
+
                 self.db.add(self._raw_poll_from_payload(payload))
                 inserted_count += 1
 
@@ -265,12 +319,15 @@ class DawumScraper:
                 self.logger.error(f"Error inserting poll: {e}")
                 continue
 
-        # Commit all successful inserts
-        if inserted_count > 0:
+        # Commit all successful inserts / updates
+        if inserted_count > 0 or updated_count > 0:
             try:
                 self.db.commit()
                 self.logger.info(
-                    f"Inserted {inserted_count} DAWUM polls, skipped {skipped_count} duplicates"
+                    "DAWUM ingest: inserted=%d updated_scope=%d skipped=%d",
+                    inserted_count,
+                    updated_count,
+                    skipped_count,
                 )
             except Exception as e:
                 self.db.rollback()
@@ -279,7 +336,7 @@ class DawumScraper:
         else:
             self.logger.info(f"No new DAWUM polls to insert (skipped {skipped_count} duplicates)")
 
-        return inserted_count
+        return inserted_count + updated_count
 
     def run(self) -> int:
         """Run the DAWUM scraper."""

--- a/src/pollingapi/scraper/dawum_parliaments.py
+++ b/src/pollingapi/scraper/dawum_parliaments.py
@@ -1,0 +1,129 @@
+"""Map DAWUM Parliament_ID values to canonical poll scope / election_id."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+from pollingapi.cleaner.transforms.references import normalized_scope, resolve_state
+from pollingapi.scraper.datamodel import ElectionScope, GermanState
+
+PARLIAMENTS_JSON = Path(__file__).resolve().parents[3] / "json" / "parliaments.json"
+
+
+@dataclass(frozen=True)
+class DawumParliamentMapping:
+    """Canonical scope + election_id for a DAWUM parliament row."""
+
+    scope: str
+    election_id: str
+    parliament_id: str
+    shortcut: str | None = None
+
+
+class UnknownDawumParliamentError(ValueError):
+    """Raised when a DAWUM parliament cannot be mapped safely."""
+
+
+@lru_cache(maxsize=1)
+def _parliament_catalog() -> dict[str, dict]:
+    if not PARLIAMENTS_JSON.exists():
+        return {}
+    raw = json.loads(PARLIAMENTS_JSON.read_text(encoding="utf-8"))
+    return {str(key): value for key, value in raw.items() if isinstance(value, dict)}
+
+
+def _election_id_for(state: GermanState, election_name: str | None) -> str:
+    text = (election_name or "").lower()
+    if "europa" in text:
+        return ElectionScope.EU_WAHLEN.value
+    if state in {GermanState.BUND, GermanState.OST, GermanState.WEST}:
+        return ElectionScope.BUNDESTAGSWAHL.value
+    return ElectionScope.LANDTAGSWAHL.value
+
+
+def _state_from_labels(*labels: str | None) -> GermanState | None:
+    """Resolve labels to a state, ignoring bare fallbacks to Bund."""
+    for label in labels:
+        if not label or not str(label).strip():
+            continue
+        text = str(label).strip()
+        state = resolve_state(text)
+        # resolve_state defaults unknown text to Bund — only accept that when
+        # the label itself clearly refers to the federal level / EU.
+        lowered = text.lower().strip()
+        federalish = lowered in {
+            "eu",
+            "bund",
+            "federal",
+            "deutschland",
+            "europawahl",
+            "bundestag",
+            "bundestagswahl",
+        } or any(
+            token in lowered
+            for token in (
+                "bundestag",
+                "federal",
+                "deutschland",
+                "europa",
+                "europäisch",
+                "europaeisch",
+            )
+        )
+        if state is GermanState.BUND and not federalish:
+            continue
+        return state
+    return None
+
+
+def map_dawum_parliament(
+    parliament_id: str | int | None,
+    *,
+    shortcut: str | None = None,
+    election: str | None = None,
+) -> DawumParliamentMapping:
+    """Map a DAWUM parliament to cleaned-poll scope and election_id.
+
+    Prefers ``json/parliaments.json`` (stable IDs + aliases). Falls back to the
+    live Shortcut/Election labels from the DAWUM dump. Never silently defaults
+    an unrecognized Landtag parliament to federal.
+    """
+    pid = "" if parliament_id is None else str(parliament_id).strip()
+    catalog = _parliament_catalog()
+    entry = catalog.get(pid) if pid else None
+
+    labels: list[str | None] = []
+    election_name = election
+    if entry:
+        aliases = entry.get("Aliases") or []
+        labels.extend(str(a) for a in aliases if a)
+        labels.append(entry.get("Shortcut"))
+        labels.append(entry.get("Name"))
+        election_name = election_name or entry.get("Election")
+        labels.append(election_name)
+    labels.extend([shortcut, election])
+
+    state = _state_from_labels(*labels)
+    if state is None:
+        raise UnknownDawumParliamentError(
+            f"Cannot map DAWUM parliament_id={pid!r} shortcut={shortcut!r} "
+            f"election={election!r} without risking a wrong federal assignment"
+        )
+
+    # Canonical API scopes: federal / be / nrw / …
+    scope = "federal" if state is GermanState.BUND else normalized_scope(state.name)
+
+    return DawumParliamentMapping(
+        scope=scope,
+        election_id=_election_id_for(state, election_name),
+        parliament_id=pid,
+        shortcut=(entry or {}).get("Shortcut") or shortcut,
+    )
+
+
+def clear_parliament_catalog_cache() -> None:
+    """Test helper to reload parliaments.json."""
+    _parliament_catalog.cache_clear()

--- a/tests/test_dawum_parliament_mapping.py
+++ b/tests/test_dawum_parliament_mapping.py
@@ -1,0 +1,182 @@
+"""Tests for DAWUM parliament → scope / election mapping and re-ingest."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from sqlalchemy import create_engine, func
+from sqlalchemy.orm import sessionmaker
+
+from pollingapi.database import Base
+from pollingapi.models import RawPoll
+from pollingapi.scraper.context import RunContext
+from pollingapi.scraper.dawum import DawumScraper
+from pollingapi.scraper.dawum_parliaments import (
+    UnknownDawumParliamentError,
+    clear_parliament_catalog_cache,
+    map_dawum_parliament,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reload_catalog():
+    clear_parliament_catalog_cache()
+    yield
+    clear_parliament_catalog_cache()
+
+
+EXPECTED_BY_ID = {
+    "0": ("federal", "Bundestagswahl"),
+    "1": ("bw", "Landtagswahl"),
+    "2": ("by", "Landtagswahl"),
+    "3": ("be", "Landtagswahl"),
+    "4": ("bb", "Landtagswahl"),
+    "5": ("hb", "Landtagswahl"),
+    "6": ("hh", "Landtagswahl"),
+    "7": ("he", "Landtagswahl"),
+    "8": ("mv", "Landtagswahl"),
+    "9": ("ni", "Landtagswahl"),
+    "10": ("nrw", "Landtagswahl"),
+    "11": ("rp", "Landtagswahl"),
+    "12": ("sl", "Landtagswahl"),
+    "13": ("sn", "Landtagswahl"),
+    "14": ("st", "Landtagswahl"),
+    "15": ("sh", "Landtagswahl"),
+    "16": ("th", "Landtagswahl"),
+    "17": ("federal", "Europawahl"),
+}
+
+
+@pytest.mark.parametrize(("parliament_id", "expected"), sorted(EXPECTED_BY_ID.items()))
+def test_map_dawum_parliament_catalog_ids(parliament_id, expected):
+    mapping = map_dawum_parliament(parliament_id)
+    assert (mapping.scope, mapping.election_id) == expected
+
+
+def test_map_dawum_parliament_berlin_live_labels():
+    mapping = map_dawum_parliament(
+        "3",
+        shortcut="Berlin",
+        election="Abgeordnetenhauswahl in Berlin",
+    )
+    assert mapping.scope == "be"
+    assert mapping.election_id == "Landtagswahl"
+
+
+def test_map_dawum_parliament_rejects_unknown_land_label():
+    with pytest.raises(UnknownDawumParliamentError):
+        map_dawum_parliament("999", shortcut="Atlantis", election="Landtagswahl in Atlantis")
+
+
+def test_prepare_db_payload_uses_parliament_scope():
+    scraper = DawumScraper(db=None, context=RunContext.for_project())
+    data = {
+        "Parliaments": {
+            "0": {"Shortcut": "Bundestag", "Election": "Bundestagswahl"},
+            "3": {"Shortcut": "Berlin", "Election": "Abgeordnetenhauswahl in Berlin"},
+            "2": {"Shortcut": "Bayern", "Election": "Landtagswahl in Bayern"},
+        },
+        "Institutes": {"1": {"Name": "Civey"}, "2": {"Name": "INSA"}},
+        "Taskers": {"1": {"Name": "Der Tagesspiegel"}},
+        "Methods": {"1": {"Name": "Online"}},
+        "Parties": {"1": {"Shortcut": "SPD"}, "2": {"Shortcut": "CDU"}, "3": {"Shortcut": "CSU"}},
+        "Surveys": {
+            "100": {
+                "Date": "2026-08-05",
+                "Survey_Period": {"Date_Start": "2026-07-20", "Date_End": "2026-08-03"},
+                "Surveyed_Persons": "3000",
+                "Parliament_ID": "3",
+                "Institute_ID": "1",
+                "Tasker_ID": "1",
+                "Method_ID": "1",
+                "Results": {"1": 12, "2": 19},
+            },
+            "101": {
+                "Date": "2026-08-04",
+                "Survey_Period": {"Date_Start": "2026-07-28", "Date_End": "2026-08-02"},
+                "Surveyed_Persons": "1000",
+                "Parliament_ID": "0",
+                "Institute_ID": "2",
+                "Tasker_ID": "1",
+                "Method_ID": "1",
+                "Results": {"1": 15, "2": 30},
+            },
+            "102": {
+                "Date": "2026-07-18",
+                "Survey_Period": {"Date_Start": "2026-07-10", "Date_End": "2026-07-15"},
+                "Surveyed_Persons": "5000",
+                "Parliament_ID": "2",
+                "Institute_ID": "1",
+                "Tasker_ID": "1",
+                "Method_ID": "1",
+                "Results": {"3": 37, "1": 6},
+            },
+        },
+    }
+    df = scraper.wrangle_data(data)
+    payloads = scraper.prepare_db_payload(df)
+    by_date = {p["publish_date"]: p for p in payloads}
+    assert by_date["2026-08-05"]["scope"] == "be"
+    assert by_date["2026-08-05"]["election_id"] == "Landtagswahl"
+    assert by_date["2026-08-04"]["scope"] == "federal"
+    assert by_date["2026-08-04"]["election_id"] == "Bundestagswahl"
+    assert by_date["2026-07-18"]["scope"] == "by"
+    assert by_date["2026-07-18"]["election_id"] == "Landtagswahl"
+
+
+def test_post_polls_updates_scope_in_place_without_duplicate(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'dawum.db'}")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    parties = {"CDU": 19.0, "SPD": 12.0, "LINKE": 21.0}
+    session.add(
+        RawPoll(
+            publish_date="2026-08-05",
+            survey_date_start="2026-07-20",
+            survey_date_end="2026-08-03",
+            respondents="3000",
+            parties=json.dumps(parties, sort_keys=True),
+            institute_id="Civey",
+            provider="DAWUM",
+            tasker="Der Tagesspiegel",
+            source="api",
+            scope="federal",
+            election_id="Bundestagswahl",
+            method_id="Online",
+            worker="dawum",
+        )
+    )
+    session.commit()
+
+    scraper = DawumScraper(db=session, context=RunContext.for_project())
+    payload = {
+        "publish_date": "2026-08-05",
+        "survey_date_start": "2026-07-20",
+        "survey_date_end": "2026-08-03",
+        "respondents": "3000",
+        "parties": parties,
+        "institute_id": "Civey",
+        "provider": "DAWUM",
+        "tasker": "Der Tagesspiegel",
+        "source": "api",
+        "scope": "be",
+        "election_id": "Landtagswahl",
+        "method_id": "Online",
+        "worker": "dawum",
+        "survey_type": None,
+        "zeitraum": None,
+    }
+
+    changed = scraper.post_polls([payload])
+    assert changed == 1
+    assert session.query(func.count(RawPoll.id)).scalar() == 1
+    row = session.query(RawPoll).one()
+    assert row.scope == "be"
+    assert row.election_id == "Landtagswahl"
+
+    # Second run is a no-op (no duplicate, no extra update count noise beyond skip)
+    changed_again = scraper.post_polls([payload])
+    assert changed_again == 0
+    assert session.query(func.count(RawPoll.id)).scalar() == 1


### PR DESCRIPTION
## Summary
- Stop hardcoding all DAWUM surveys as `federal` / `Bundestagswahl`
- Map `Parliament_ID` via `json/parliaments.json` to canonical scopes (`be`, `by`, `nrw`, …; EU → `federal` + `Europawahl`)
- On re-ingest, correct mis-scoped raw rows **in place** (identity without scope) so Landtag polls are not duplicated

## Why
Berlin Civey/Tagesspiegel (2026-08-05) and other Landtag rows were ingested as federal, failed federal QC (`CDU` vs `CDU_CSU`), and never appeared under `scope=be`.

## Test plan
- [x] `pytest tests/test_dawum_parliament_mapping.py` (22 tests)
- [x] Live DAWUM dump: 3892/3892 surveys mapped (145 → `be`)
- [ ] After merge on FastTrack: `git pull` + `uv run pollingapi scraper:run dawum` + `uv run pollingapi pipeline:clean` (or full `pipeline:run`)
- [ ] Confirm `/v2/polls?scope=be` includes Civey 2026-08-05